### PR TITLE
전역 예외 처리를 구현한다

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/exception/ErrorResponse.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/ErrorResponse.java
@@ -1,5 +1,6 @@
 package dalgrock.playlist.controller.exception;
 
+import dalgrock.playlist.core.exception.ErrorCode;
 import java.time.LocalDateTime;
 
 public record ErrorResponse(
@@ -10,5 +11,9 @@ public record ErrorResponse(
 
     public static ErrorResponse of(String code, String message) {
         return new ErrorResponse(code, message, LocalDateTime.now());
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.getCode(), errorCode.getMessage(), LocalDateTime.now());
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/exception/ErrorResponse.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/ErrorResponse.java
@@ -1,0 +1,14 @@
+package dalgrock.playlist.controller.exception;
+
+import java.time.LocalDateTime;
+
+public record ErrorResponse(
+        String code,
+        String message,
+        LocalDateTime timestamp
+) {
+
+    public static ErrorResponse of(String code, String message) {
+        return new ErrorResponse(code, message, LocalDateTime.now());
+    }
+}

--- a/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
@@ -1,0 +1,32 @@
+package dalgrock.playlist.controller.exception;
+
+import dalgrock.playlist.core.exception.BusinessException;
+import dalgrock.playlist.core.exception.ErrorCode;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        ErrorCode errorCode = e.getErrorCode();
+        ErrorResponse response = ErrorResponse.of(errorCode.getCode(), e.getMessage());
+        return new ResponseEntity<>(response, errorCode.getStatus());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        ErrorResponse response = ErrorResponse.of("C001", "입력값이 유효하지 않습니다.");
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        ErrorResponse response = ErrorResponse.of("S001", "서버 내부 오류가 발생했습니다.");
+        return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+    }
+}

--- a/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package dalgrock.playlist.controller.exception;
 
 import dalgrock.playlist.core.exception.BusinessException;
 import dalgrock.playlist.core.exception.ErrorCode;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,22 +13,24 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    private static final Log log = LogFactory.getLog(GlobalExceptionHandler.class);
+
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
-        ErrorResponse response = ErrorResponse.of(errorCode.getCode(), e.getMessage());
+        ErrorResponse response = ErrorResponse.of(errorCode);
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
-        ErrorResponse response = ErrorResponse.of("C001", "입력값이 유효하지 않습니다.");
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
-        ErrorResponse response = ErrorResponse.of("S001", "서버 내부 오류가 발생했습니다.");
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
@@ -2,8 +2,7 @@ package dalgrock.playlist.controller.exception;
 
 import dalgrock.playlist.core.exception.BusinessException;
 import dalgrock.playlist.core.exception.ErrorCode;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -11,25 +10,28 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Slf4j
 public class GlobalExceptionHandler {
-
-    private static final Log log = LogFactory.getLog(GlobalExceptionHandler.class);
 
     @ExceptionHandler(BusinessException.class)
     protected ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
         ErrorCode errorCode = e.getErrorCode();
+        log.warn("BusinessException: code={}, message={}", errorCode.getCode(), e.getMessage());
         ErrorResponse response = ErrorResponse.of(errorCode);
         return new ResponseEntity<>(response, errorCode.getStatus());
     }
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        log.warn("MethodArgumentNotValidException: {}", errorMessage);
         ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+        log.error("Internal Server Error: ", e);
         ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
         return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/dalgrock/playlist/core/exception/BusinessException.java
+++ b/src/main/java/dalgrock/playlist/core/exception/BusinessException.java
@@ -1,0 +1,15 @@
+package dalgrock.playlist.core.exception;
+
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
+++ b/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
@@ -1,0 +1,23 @@
+package dalgrock.playlist.core.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
+    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 오류가 발생했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String code, String message) {
+        this.status = status;
+        this.code = code;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
## IssueNumber

closed #2 

## As-is

- 예외처리 시 응답 형식이 지정되지 않아 서로 다른 응답을 보내게 됩니다.

## To-be

- 이를 해결하고자 전역 예외처리 설정을 추가합니다.

## Additional Description

기본적인 전역 처리 코드만 추가했습니다. 
`ErrorCode` enum 안에 예외 발생 시 반환값들을 예시로 작성해두었는데 이야기 나누며 구체화 시키면 좋을 것 같습니다!

```java
public enum ErrorCode {

    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "U001", "사용자를 찾을 수 없습니다."),
    INVALID_INPUT_VALUE(HttpStatus.BAD_REQUEST, "C001", "잘못된 입력값입니다."),
    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S001", "서버 내부 오류가 발생했습니다."),
    ...
}
```

피드백&질문 대환영