### PR TITLE
기록 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-webmvc'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.3'

--- a/src/main/java/dalgrock/playlist/config/JpaAuditConfig.java
+++ b/src/main/java/dalgrock/playlist/config/JpaAuditConfig.java
@@ -1,9 +1,18 @@
 package dalgrock.playlist.config;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @Configuration
-@EnableJpaAuditing
+@EnableJpaAuditing(dateTimeProviderRef = "dateTimeProvider")
 public class JpaAuditConfig {
+
+    @Bean
+    public DateTimeProvider dateTimeProvider() {
+        return () -> Optional.of(LocalDateTime.now());
+    }
 }

--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -2,12 +2,16 @@ package dalgrock.playlist.controller;
 
 import dalgrock.playlist.model.UserPrincipal;
 import dalgrock.playlist.service.RecordService;
+import dalgrock.playlist.service.dto.command.CreateRecordCommand;
+import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -25,5 +29,13 @@ public class RecordControllerV1 {
             @PathVariable("recordId") Long recordId
     ) {
         return recordService.getRecordDetail(principal.userId(), recordId);
+    }
+
+    @PostMapping("/")
+    public CreateRecordResponse createRecord(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestBody CreateRecordCommand command
+    ) {
+        return recordService.createRecord(principal.userId(), command);
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -1,19 +1,26 @@
 package dalgrock.playlist.controller;
 
+import dalgrock.playlist.controller.dto.request.CreateRecordRequest;
 import dalgrock.playlist.model.UserPrincipal;
 import dalgrock.playlist.service.RecordService;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
+import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @SecurityRequirement(name = "cookieAuth")
 @RequiredArgsConstructor
@@ -31,11 +38,26 @@ public class RecordControllerV1 {
         return recordService.getRecordDetail(principal.userId(), recordId);
     }
 
-    @PostMapping("/")
+    @PostMapping()
+    @ResponseStatus(HttpStatus.CREATED)
     public CreateRecordResponse createRecord(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestBody CreateRecordCommand command
+            @RequestBody CreateRecordRequest request
     ) {
+        CreateRecordCommand command = toCommand(request);
         return recordService.createRecord(principal.userId(), command);
+    }
+
+    private CreateRecordCommand toCommand(CreateRecordRequest request) {
+        List<CreateRecordMusicCommand> musicCommands = request.musics().stream()
+                .map(m -> new CreateRecordMusicCommand(m.title(), m.artist(), m.thumbnail()))
+                .collect(Collectors.toList());
+        return new CreateRecordCommand(
+                musicCommands,
+                request.emotions(),
+                request.content(),
+                request.situations(),
+                request.location()
+        );
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/TestController.java
+++ b/src/main/java/dalgrock/playlist/controller/TestController.java
@@ -1,7 +1,10 @@
 package dalgrock.playlist.controller;
 
 import dalgrock.playlist.core.jwt.JwtTokenProvider;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -11,11 +14,23 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/test")
 public class TestController {
 
+    private static final String COOKIE_NAME = "access_token";
+
     private final JwtTokenProvider tokenProvider;
 
+    @Value("${jwt.expiration}")
+    private long jwtExpirationMs;
+
     @GetMapping("/token")
-    public String generateToken() {
+    public String generateToken(HttpServletResponse response) {
         String token = tokenProvider.createAccessToken(1L, "USER");
+
+        Cookie cookie = new Cookie(COOKIE_NAME, token);
+        cookie.setHttpOnly(true);
+        cookie.setPath("/");
+        cookie.setMaxAge((int) (jwtExpirationMs / 1000));
+        response.addCookie(cookie);
+
         return token;
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
+++ b/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
@@ -1,0 +1,36 @@
+package dalgrock.playlist.controller.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record CreateRecordRequest(
+        @NotNull
+        @Size(min = 1)
+        List<Music> musics,
+
+        @NotNull
+        @Size(min = 1)
+        List<String> emotions,
+        
+        String content,
+        
+        List<String> situations,
+
+
+        String location
+) {
+
+    public record Music(
+        @NotNull    
+        String title,
+        
+        @NotNull    
+        String artist,
+        
+        @NotNull
+        String thumbnail
+    ) {
+    }
+}

--- a/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
+++ b/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
@@ -22,6 +22,7 @@ public enum ErrorCode {
 
     // Record
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "내 기록을 찾을 수 없습니다."),
+    RECORD_ALREADY_EXISTS_TODAY(HttpStatus.CONFLICT, "R002", "오늘 이미 기록을 등록했습니다."),
 
     // Weekly
     WEEKLY_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "주차를 찾을 수 없습니다."),

--- a/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
+++ b/src/main/java/dalgrock/playlist/core/exception/ErrorCode.java
@@ -22,6 +22,9 @@ public enum ErrorCode {
 
     // Record
     RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "내 기록을 찾을 수 없습니다."),
+
+    // Weekly
+    WEEKLY_NOT_FOUND(HttpStatus.NOT_FOUND, "W001", "주차를 찾을 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/dalgrock/playlist/core/exception/RecordAlreadyExistsTodayException.java
+++ b/src/main/java/dalgrock/playlist/core/exception/RecordAlreadyExistsTodayException.java
@@ -1,0 +1,8 @@
+package dalgrock.playlist.core.exception;
+
+public class RecordAlreadyExistsTodayException extends BusinessException {
+
+    public RecordAlreadyExistsTodayException() {
+        super(ErrorCode.RECORD_ALREADY_EXISTS_TODAY);
+    }
+}

--- a/src/main/java/dalgrock/playlist/core/exception/WeeklyNotFoundException.java
+++ b/src/main/java/dalgrock/playlist/core/exception/WeeklyNotFoundException.java
@@ -1,0 +1,8 @@
+package dalgrock.playlist.core.exception;
+
+public class WeeklyNotFoundException extends BusinessException {
+
+    public WeeklyNotFoundException(String message) {
+        super(ErrorCode.WEEKLY_NOT_FOUND);
+    }
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/MusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/MusicRepository.java
@@ -1,4 +1,11 @@
 package dalgrock.playlist.infrastructure.repository;
 
+import dalgrock.playlist.model.Music;
+import java.util.Optional;
+
 public interface MusicRepository {
+
+    Optional<Music> findByArtistAndTitle(String artist, String title);
+
+    Music save(Music music);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
@@ -9,4 +9,6 @@ public interface RecordMusicRepository {
     List<GetRecordMusicDto> findAllByRecordId(Long id);
 
     RecordMusic save(RecordMusic recordMusic);
+
+    List<RecordMusic> saveAll(List<RecordMusic> recordMusics);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
@@ -1,9 +1,12 @@
 package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
+import dalgrock.playlist.model.RecordMusic;
 import java.util.List;
 
 public interface RecordMusicRepository {
 
     List<GetRecordMusicDto> findAllByRecordId(Long id);
+
+    RecordMusic save(RecordMusic recordMusic);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
@@ -6,4 +6,6 @@ import java.util.Optional;
 public interface RecordRepository {
 
     Optional<Record> findById(Long id);
+
+    Record save(Record record);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.model.Record;
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface RecordRepository {
@@ -8,4 +9,6 @@ public interface RecordRepository {
     Optional<Record> findById(Long id);
 
     Record save(Record record);
+
+    boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
@@ -6,4 +6,8 @@ import java.util.Optional;
 public interface WeeklyRepository {
 
     Optional<Weekly> findById(Long id);
+
+    Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week);
+
+    Weekly save(Weekly weekly);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
@@ -1,0 +1,9 @@
+package dalgrock.playlist.infrastructure.repository;
+
+import dalgrock.playlist.model.Weekly;
+import java.util.Optional;
+
+public interface WeeklyRepository {
+
+    Optional<Weekly> findById(Long id);
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaMusicRepository.java
@@ -1,7 +1,10 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Music;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaMusicRepository extends JpaRepository<Music, Long> {
+
+    Optional<Music> findByArtistAndTitle(String artist, String title);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
@@ -1,7 +1,10 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Record;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaRecordRepository extends JpaRepository<Record, Long> {
+
+    boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
@@ -1,7 +1,10 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Weekly;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaWeeklyRepository extends JpaRepository<Weekly, Long> {
+
+    Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
@@ -1,0 +1,7 @@
+package dalgrock.playlist.infrastructure.repository.jpa;
+
+import dalgrock.playlist.model.Weekly;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface JpaWeeklyRepository extends JpaRepository<Weekly, Long> {
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/MusicRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/MusicRepositoryAdapter.java
@@ -1,6 +1,8 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.MusicRepository;
+import dalgrock.playlist.model.Music;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,14 @@ import org.springframework.stereotype.Repository;
 public class MusicRepositoryAdapter implements MusicRepository {
 
     private final JpaMusicRepository jpaMusicRepository;
+
+    @Override
+    public Optional<Music> findByArtistAndTitle(String artist, String title) {
+        return jpaMusicRepository.findByArtistAndTitle(artist, title);
+    }
+
+    @Override
+    public Music save(Music music) {
+        return jpaMusicRepository.save(music);
+    }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
@@ -22,4 +22,9 @@ public class RecordMusicRepositoryAdapter implements RecordMusicRepository {
     public RecordMusic save(RecordMusic recordMusic) {
         return jpaRecordMusicRepository.save(recordMusic);
     }
+
+    @Override
+    public List<RecordMusic> saveAll(List<RecordMusic> recordMusics) {
+        return jpaRecordMusicRepository.saveAll(recordMusics);
+    }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.RecordMusicRepository;
 import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
+import dalgrock.playlist.model.RecordMusic;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -15,5 +16,10 @@ public class RecordMusicRepositoryAdapter implements RecordMusicRepository {
     @Override
     public List<GetRecordMusicDto> findAllByRecordId(Long id) {
         return jpaRecordMusicRepository.findAllByRecordId(id);
+    }
+
+    @Override
+    public RecordMusic save(RecordMusic recordMusic) {
+        return jpaRecordMusicRepository.save(recordMusic);
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
 import dalgrock.playlist.model.Record;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,5 +21,10 @@ public class RecordRepositoryAdapter implements RecordRepository {
     @Override
     public Record save(Record record) {
         return jpaRecordRepository.save(record);
+    }
+
+    @Override
+    public boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end) {
+        return jpaRecordRepository.existsByUserIdAndCreatedAtBetween(userId, start, end);
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
@@ -16,4 +16,9 @@ public class RecordRepositoryAdapter implements RecordRepository {
     public Optional<Record> findById(Long id) {
         return jpaRecordRepository.findById(id);
     }
+
+    @Override
+    public Record save(Record record) {
+        return jpaRecordRepository.save(record);
+    }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
@@ -16,4 +16,14 @@ public class WeeklyRepositoryAdapter implements WeeklyRepository {
     public Optional<Weekly> findById(Long id) {
         return jpaWeeklyRepository.findById(id);
     }
+
+    @Override
+    public Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week) {
+        return jpaWeeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+    }
+
+    @Override
+    public Weekly save(Weekly weekly) {
+        return jpaWeeklyRepository.save(weekly);
+    }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
@@ -1,0 +1,19 @@
+package dalgrock.playlist.infrastructure.repository.jpa;
+
+import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
+import dalgrock.playlist.model.Weekly;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class WeeklyRepositoryAdapter implements WeeklyRepository {
+
+    private final JpaWeeklyRepository jpaWeeklyRepository;
+
+    @Override
+    public Optional<Weekly> findById(Long id) {
+        return jpaWeeklyRepository.findById(id);
+    }
+}

--- a/src/main/java/dalgrock/playlist/model/Weekly.java
+++ b/src/main/java/dalgrock/playlist/model/Weekly.java
@@ -25,5 +25,13 @@ public class Weekly extends BaseTimeEntity {
     private Long id;
 
     private String title;
-    
+
+    @Column(nullable = false)
+    private int year;
+
+    @Column(nullable = false)
+    private int month;
+
+    @Column(nullable = false)
+    private int week;
 }

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -3,7 +3,6 @@ package dalgrock.playlist.service;
 import dalgrock.playlist.core.exception.ErrorCode;
 import dalgrock.playlist.core.exception.RecordNotFoundException;
 import dalgrock.playlist.core.exception.UnauthorizedException;
-import dalgrock.playlist.core.exception.WeeklyNotFoundException;
 import dalgrock.playlist.infrastructure.repository.MusicRepository;
 import dalgrock.playlist.infrastructure.repository.RecordMusicRepository;
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
@@ -20,6 +19,8 @@ import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -54,8 +55,12 @@ public class RecordService {
 
     @Transactional
     public CreateRecordResponse createRecord(Long userId, CreateRecordCommand command) {
-        Weekly weekly = weeklyRepository.findById(command.weeklyId())
-                .orElseThrow(() -> new WeeklyNotFoundException(ErrorCode.WEEKLY_NOT_FOUND.getMessage()));
+        LocalDate today = LocalDate.now();
+        int year = getYearOfWeek(today);
+        int month = getMonthOfWeek(today);
+        int week = getWeekOfMonth(today);
+
+        Weekly weekly = findOrCreateWeekly(year, month, week);
 
         List<Emotion> emotions = new ArrayList<>(toEmotions(command.emotions()));
         List<Situation> situations = new ArrayList<>(toSituations(command.situations()));
@@ -120,6 +125,35 @@ public class RecordService {
                             .genre(null)
                             .build();
                     return musicRepository.save(newMusic);
+                });
+    }
+
+    /**
+     * 주차는 월요일 시작 ~ 일요일 끝.
+     * 오늘 날짜가 속한 주의 월요일 기준으로 (year, month, week) 계산.
+     */
+    private int getYearOfWeek(LocalDate date) {
+        return date.with(DayOfWeek.MONDAY).getYear();
+    }
+
+    private int getMonthOfWeek(LocalDate date) {
+        return date.with(DayOfWeek.MONDAY).getMonthValue();
+    }
+
+    private int getWeekOfMonth(LocalDate date) {
+        LocalDate monday = date.with(DayOfWeek.MONDAY);
+        return (monday.getDayOfMonth() - 1) / 7 + 1;
+    }
+
+    private Weekly findOrCreateWeekly(int year, int month, int week) {
+        return weeklyRepository.findByYearAndMonthAndWeek(year, month, week)
+                .orElseGet(() -> {
+                    Weekly newWeekly = Weekly.builder()
+                            .year(year)
+                            .month(month)
+                            .week(week)
+                            .build();
+                    return weeklyRepository.save(newWeekly);
                 });
     }
 }

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -65,10 +65,9 @@ public class RecordService {
             throw new RecordAlreadyExistsTodayException();
         }
 
-        LocalDate todayForWeekly = LocalDate.now();
-        int year = getYearOfWeek(todayForWeekly);
-        int month = getMonthOfWeek(todayForWeekly);
-        int week = getWeekOfMonth(todayForWeekly);
+        int year = getYearOfWeek(today);
+        int month = getMonthOfWeek(today);
+        int week = getWeekOfMonth(today);
 
         Weekly weekly = findOrCreateWeekly(year, month, week);
 

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -123,8 +123,8 @@ public class RecordService {
     }
 
     private Music findOrCreateMusic(CreateRecordMusicCommand command) {
-        String artist = command.artist() != null ? command.artist() : "";
-        String title = command.title() != null ? command.title() : "";
+        String artist = command.artist();
+        String title = command.title();
         return musicRepository.findByArtistAndTitle(artist, title)
                 .orElseGet(() -> {
                     Music newMusic = Music.builder()

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -3,15 +3,28 @@ package dalgrock.playlist.service;
 import dalgrock.playlist.core.exception.ErrorCode;
 import dalgrock.playlist.core.exception.RecordNotFoundException;
 import dalgrock.playlist.core.exception.UnauthorizedException;
+import dalgrock.playlist.core.exception.WeeklyNotFoundException;
+import dalgrock.playlist.infrastructure.repository.MusicRepository;
 import dalgrock.playlist.infrastructure.repository.RecordMusicRepository;
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
+import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
 import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
+import dalgrock.playlist.model.Emotion;
+import dalgrock.playlist.model.Music;
 import dalgrock.playlist.model.Record;
-import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
+import dalgrock.playlist.model.RecordMusic;
+import dalgrock.playlist.model.Situation;
+import dalgrock.playlist.model.Weekly;
+import dalgrock.playlist.service.dto.command.CreateRecordCommand;
+import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
+import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
+import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
+import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -19,6 +32,8 @@ public class RecordService {
 
     private final RecordRepository recordRepository;
     private final RecordMusicRepository recordMusicRepository;
+    private final MusicRepository musicRepository;
+    private final WeeklyRepository weeklyRepository;
 
     public GetRecordDetailResponse getRecordDetail(Long userId, Long recordId) {
         Record record = recordRepository.findById(recordId)
@@ -35,5 +50,76 @@ public class RecordService {
                 .toList();
 
         return GetRecordDetailResponse.of(record, recordMusicResponses);
+    }
+
+    @Transactional
+    public CreateRecordResponse createRecord(Long userId, CreateRecordCommand command) {
+        Weekly weekly = weeklyRepository.findById(command.weeklyId())
+                .orElseThrow(() -> new WeeklyNotFoundException(ErrorCode.WEEKLY_NOT_FOUND.getMessage()));
+
+        List<Emotion> emotions = new ArrayList<>(toEmotions(command.emotions()));
+        List<Situation> situations = new ArrayList<>(toSituations(command.situations()));
+
+        String thumbnail = command.musics() != null && !command.musics().isEmpty()
+                ? command.musics().get(0).thumbnail()
+                : "";
+
+        Record record = Record.builder()
+                .userId(userId)
+                .thumbnail(thumbnail != null ? thumbnail : "")
+                .location(command.location())
+                .content(command.content())
+                .emotions(emotions)
+                .situations(situations)
+                .weekly(weekly)
+                .build();
+
+        Record savedRecord = recordRepository.save(record);
+
+        if (command.musics() != null) {
+            for (CreateRecordMusicCommand musicCommand : command.musics()) {
+                Music music = findOrCreateMusic(musicCommand);
+                RecordMusic recordMusic = RecordMusic.builder()
+                        .recordId(savedRecord.getId())
+                        .musicId(music.getId())
+                        .build();
+                recordMusicRepository.save(recordMusic);
+            }
+        }
+
+        return CreateRecordResponse.from(savedRecord);
+    }
+
+    private List<Emotion> toEmotions(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .map(value -> new Emotion("", value))
+                .toList();
+    }
+
+    private List<Situation> toSituations(List<String> values) {
+        if (values == null) {
+            return List.of();
+        }
+        return values.stream()
+                .map(value -> new Situation("", value))
+                .toList();
+    }
+
+    private Music findOrCreateMusic(CreateRecordMusicCommand command) {
+        String artist = command.artist() != null ? command.artist() : "";
+        String title = command.title() != null ? command.title() : "";
+        return musicRepository.findByArtistAndTitle(artist, title)
+                .orElseGet(() -> {
+                    Music newMusic = Music.builder()
+                            .artist(artist)
+                            .title(title)
+                            .thumbnail(command.thumbnail() != null ? command.thumbnail() : "")
+                            .genre(null)
+                            .build();
+                    return musicRepository.save(newMusic);
+                });
     }
 }

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.service;
 
 import dalgrock.playlist.core.exception.ErrorCode;
+import dalgrock.playlist.core.exception.RecordAlreadyExistsTodayException;
 import dalgrock.playlist.core.exception.RecordNotFoundException;
 import dalgrock.playlist.core.exception.UnauthorizedException;
 import dalgrock.playlist.infrastructure.repository.MusicRepository;
@@ -21,6 +22,7 @@ import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -56,9 +58,17 @@ public class RecordService {
     @Transactional
     public CreateRecordResponse createRecord(Long userId, CreateRecordCommand command) {
         LocalDate today = LocalDate.now();
-        int year = getYearOfWeek(today);
-        int month = getMonthOfWeek(today);
-        int week = getWeekOfMonth(today);
+        LocalDateTime startOfDay = today.atStartOfDay();
+        LocalDateTime startOfNextDay = today.plusDays(1).atStartOfDay();
+
+        if (recordRepository.existsByUserIdAndCreatedAtBetween(userId, startOfDay, startOfNextDay)) {
+            throw new RecordAlreadyExistsTodayException();
+        }
+
+        LocalDate todayForWeekly = LocalDate.now();
+        int year = getYearOfWeek(todayForWeekly);
+        int month = getMonthOfWeek(todayForWeekly);
+        int week = getWeekOfMonth(todayForWeekly);
 
         Weekly weekly = findOrCreateWeekly(year, month, week);
 

--- a/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
@@ -7,7 +7,6 @@ public record CreateRecordCommand(
         List<String> emotions,
         String content,
         List<String> situations,
-        String location,
-        Long weeklyId
+        String location
 ) {
 }

--- a/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
@@ -1,0 +1,13 @@
+package dalgrock.playlist.service.dto.command;
+
+import java.util.List;
+
+public record CreateRecordCommand(
+        List<CreateRecordMusicCommand> musics,
+        List<String> emotions,
+        String content,
+        List<String> situations,
+        String location,
+        Long weeklyId
+) {
+}

--- a/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordMusicCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordMusicCommand.java
@@ -1,0 +1,8 @@
+package dalgrock.playlist.service.dto.command;
+
+public record CreateRecordMusicCommand(
+        String title,
+        String artist,
+        String thumbnail
+) {
+}

--- a/src/main/java/dalgrock/playlist/service/dto/response/CreateRecordResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/CreateRecordResponse.java
@@ -1,0 +1,10 @@
+package dalgrock.playlist.service.dto.response;
+
+import dalgrock.playlist.model.Record;
+
+public record CreateRecordResponse(Long id) {
+
+    public static CreateRecordResponse from(Record record) {
+        return new CreateRecordResponse(record.getId());
+    }
+}

--- a/src/main/resources/seed-user1-records.sql
+++ b/src/main/resources/seed-user1-records.sql
@@ -1,0 +1,88 @@
+-- userId 1번 테스트 유저: 이번주·저번주·저저번주 기록 시딩 (월요일 기준 주차)
+-- PostgreSQL. 실행: psql 또는 DB 클라이언트에서 실행
+
+-- 1) Weekly 3개 (이번주, 저번주, 저저번주)
+--    주차: year, month, week (월요일 시작 기준)
+INSERT INTO weekly (id, title, year, month, week, created_at, updated_at)
+VALUES
+  (100, '2026년 2월 2주차', 2026, 2, 2, NOW(), NOW()),
+  (101, '2026년 2월 1주차', 2026, 2, 1, NOW(), NOW()),
+  (102, '2026년 1월 4주차', 2026, 1, 4, NOW(), NOW())
+ON CONFLICT DO NOTHING;
+
+-- 2) Records: 이번주 1개, 저번주 5개, 저저번주 6개 (user_id = 1)
+INSERT INTO records (id, user_id, weekly_id, thumbnail, location, content, created_at, updated_at)
+VALUES
+  (200, 1, 100, 'https://example.com/thumb1.png', '서울', '이번주 기록 내용', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
+  (201, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 1', NOW() - INTERVAL '9 days', NOW() - INTERVAL '9 days'),
+  (202, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 2', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days'),
+  (203, 1, 101, 'https://example.com/thumb2.png', '퇴근길', '저번주 기록 3', NOW() - INTERVAL '7 days', NOW() - INTERVAL '7 days'),
+  (204, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 4', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days'),
+  (205, 1, 101, 'https://example.com/thumb2.png', '부산', '저번주 기록 5', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days'),
+  (206, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 1', NOW() - INTERVAL '16 days', NOW() - INTERVAL '16 days'),
+  (207, 1, 102, 'https://example.com/thumb3.png', '회사', '저저번주 기록 2', NOW() - INTERVAL '15 days', NOW() - INTERVAL '15 days'),
+  (208, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 3', NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
+  (209, 1, 102, 'https://example.com/thumb3.png', '부산', '저저번주 기록 4', NOW() - INTERVAL '13 days', NOW() - INTERVAL '13 days'),
+  (210, 1, 102, 'https://example.com/thumb3.png', '카페', '저저번주 기록 5', NOW() - INTERVAL '12 days', NOW() - INTERVAL '12 days'),
+  (211, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 6', NOW() - INTERVAL '11 days', NOW() - INTERVAL '11 days')
+ON CONFLICT DO NOTHING;
+
+-- 3) Emotions (record_id 200~211)
+INSERT INTO emotions (record_id, category, value)
+VALUES
+  (200, '', '기쁨'),
+  (200, '', '설렘'),
+  (201, '', '평온'),
+  (201, '', '감사'),
+  (202, '', '신남'),
+  (202, '', '기대'),
+  (203, '', '행복'),
+  (203, '', '편안'),
+  (204, '', '설렘'),
+  (204, '', '기쁨'),
+  (205, '', '감사'),
+  (205, '', '평온'),
+  (206, '', '신남'),
+  (206, '', '기대'),
+  (207, '', '행복'),
+  (207, '', '편안'),
+  (208, '', '설렘'),
+  (208, '', '기쁨'),
+  (209, '', '감사'),
+  (209, '', '평온'),
+  (210, '', '신남'),
+  (210, '', '기대'),
+  (211, '', '행복'),
+  (211, '', '편안');
+
+-- 4) Situations (record_id 200~211)
+INSERT INTO situations (record_id, category, value)
+VALUES
+  (200, '', '출퇴근'),
+  (200, '', '휴식'),
+  (201, '', '운동'),
+  (201, '', '독서'),
+  (202, '', '여행'),
+  (202, '', '맛집'),
+  (203, '', '출퇴근'),
+  (203, '', '휴식'),
+  (204, '', '운동'),
+  (204, '', '독서'),
+  (205, '', '여행'),
+  (205, '', '맛집'),
+  (206, '', '출퇴근'),
+  (206, '', '휴식'),
+  (207, '', '운동'),
+  (207, '', '독서'),
+  (208, '', '여행'),
+  (208, '', '맛집'),
+  (209, '', '출퇴근'),
+  (209, '', '휴식'),
+  (210, '', '운동'),
+  (210, '', '독서'),
+  (211, '', '여행'),
+  (211, '', '맛집');
+
+-- 5) 시퀀스 갱신 (다음 INSERT 시 id 충돌 방지, 이미 사용 중인 max id보다 크게)
+SELECT setval(pg_get_serial_sequence('weekly', 'id'), (SELECT COALESCE(MAX(id), 1) FROM weekly));
+SELECT setval(pg_get_serial_sequence('records', 'id'), (SELECT COALESCE(MAX(id), 1) FROM records));


### PR DESCRIPTION
## Issue Number
closed #8 

## As-is
- 내 기록을 생성할 수 없었습니다.
- 기록에 포함할 음악 목록, 감정, 상황, 주차(weekly) 정보를 함께 저장할 수 없었습니다.

## To-be

- 내 기록 생성 기능을 구현합니다.
- POST /v1/records 로 기록 생성 시 musics, emotions, situations, location, content 를 받아 저장합니다. (weeklyId는 요청에서 받지 않음)
- 날짜 기준 주차 자동 계산: 요청 시점의 날짜를 기준으로 이번 주(월요일~일요일) 의 year, month, week를 계산하고, Weekly 테이블에 해당 (year, month, week) 행이 있으면 그 id를 사용하고, 없으면 insert 후 해당 id로 기록을 연결합니다. Weekly 엔티티에 year, month, week (number) 컬럼을 추가했습니다.
- 하루 1회 기록 제한: 동일 사용자(userId)가 당일 이미 기록을 등록한 경우 409 Conflict 및 "오늘 이미 기록을 등록했습니다" 메시지로 응답하며, 당일 추가 기록 생성을 막습니다.
- 음악은 artist + title 기준으로 조회 후 없으면 생성하고, record_music 으로 기록과 연결합니다.
- 생성된 기록의 id 만 담은 CreateRecordResponse 로 응답합니다.
- 인가 시 사용자 정보를 UserPrincipal 로 받아와, 해당 사용자 소유로 기록을 생성합니다.
- 기록 생성·음악 조회/생성·record_music 저장은 하나의 트랜잭션(`@Transactional`)으로 처리합니다.
- 엔티티 createdAt / updatedAt 은 JPA Auditing(DateTimeProvider)으로 저장·수정 시점에 자동 설정됩니다.

## Additional Description

- 테스트용 토큰 발급 API(GET /test/token)에서 발급한 JWT를 Set-Cookie(access_token)로 내려주도록 추가했습니다.
- 시딩: userId 1 테스트용 seed-user1-records.sql 을 추가했습니다. 이번 주 1건, 저번 주 5건, 저저번 주 6건의 더미 기록(emotions, situations 포함)을 한 번에 넣을 수 있으며, PostgreSQL에서 직접 실행해 사용합니다.