### PR TITLE
이번주 내 기록 조회

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -62,7 +62,7 @@ public class RecordControllerV1 {
         );
     }
 
-    @GetMapping("/")
+    @GetMapping()
     public GetRecordResponse getRecords(
             @AuthenticationPrincipal UserPrincipal principal
     ) {

--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -5,6 +5,7 @@ import dalgrock.playlist.service.RecordService;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
+import dalgrock.playlist.service.dto.response.GetRecordResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -37,5 +38,12 @@ public class RecordControllerV1 {
             @RequestBody CreateRecordCommand command
     ) {
         return recordService.createRecord(principal.userId(), command);
+    }
+
+    @GetMapping("/")
+    public GetRecordResponse getRecords(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return recordService.getRecords(principal.userId());
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.model.Record;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface RecordRepository {
@@ -11,4 +12,6 @@ public interface RecordRepository {
     Record save(Record record);
 
     boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    List<Record> findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
@@ -2,9 +2,15 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Record;
 import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaRecordRepository extends JpaRepository<Record, Long> {
 
     boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    @Query("SELECT r FROM Record r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds")
+    List<Record> findByUserIdAndWeeklyIdInFetchWeekly(@Param("userId") Long userId, @Param("weeklyIds") List<Long> weeklyIds);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
@@ -3,6 +3,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
 import dalgrock.playlist.model.Record;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -26,5 +27,10 @@ public class RecordRepositoryAdapter implements RecordRepository {
     @Override
     public boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end) {
         return jpaRecordRepository.existsByUserIdAndCreatedAtBetween(userId, start, end);
+    }
+
+    @Override
+    public List<Record> findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds) {
+        return jpaRecordRepository.findByUserIdAndWeeklyIdInFetchWeekly(userId, weeklyIds);
     }
 }

--- a/src/main/java/dalgrock/playlist/model/RecordMusic.java
+++ b/src/main/java/dalgrock/playlist/model/RecordMusic.java
@@ -27,4 +27,11 @@ public class RecordMusic extends BaseTimeEntity {
 
     private Long recordId;
     private Long musicId;
+
+    public static RecordMusic of(Record record, Music music) {
+        return RecordMusic.builder()
+                .recordId(record.getId())
+                .musicId(music.getId())
+                .build();
+    }
 }

--- a/src/main/java/dalgrock/playlist/model/Weekly.java
+++ b/src/main/java/dalgrock/playlist/model/Weekly.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,7 +18,10 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity(name = "weekly")
-@Table(name = "weekly")
+@Table(
+        name = "weekly",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"year", "month", "week"})
+)
 public class Weekly extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -24,6 +24,9 @@ import dalgrock.playlist.service.dto.response.GetRecordResponse;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -58,75 +61,63 @@ public class RecordService {
         return GetRecordDetailResponse.of(record, recordMusicResponses);
     }
 
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
+
     /**
-     * 오늘·7일 전·14일 전 주차의 (year, month, week)로 해당 userId의 records를 조회한 뒤,
-     * 이번주 → 7일 전 주 → 14일 전 주 순으로 응답을 가공하여 반환.
+     * 이번 주(월요일~일요일)에 해당하는 userId의 records를 조회하여
+     * recordId, createdAt, musics(thumbnail), emotions 형태로 반환.
+     * 주의 시작은 월요일, 끝은 일요일. 기준 시간대는 Asia/Seoul.
      */
     public GetRecordResponse getRecords(Long userId) {
-        LocalDate today = LocalDate.now();
-        List<LocalDate> weekDates = List.of(today, today.minusDays(7), today.minusDays(14));
+        LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
+        LocalDate weekMonday = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDate weekSunday = weekMonday.plusDays(6);
 
-        List<WeekContext> weekContexts = weekDates.stream()
-                .map(d -> {
-                    int y = getYearOfWeek(d);
-                    int m = getMonthOfWeek(d);
-                    int w = getWeekOfMonth(d);
-                    return new WeekContext(y, m, w, weeklyRepository.findByYearAndMonthAndWeek(y, m, w));
-                })
-                .toList();
+        int year = getYearOfWeek(today);
+        int month = getMonthOfWeek(today);
+        int week = getWeekOfMonth(today);
 
-        List<Long> weeklyIds = weekContexts.stream()
-                .flatMap(wc -> wc.weeklyOpt().stream())
-                .map(Weekly::getId)
-                .toList();
+        Optional<Weekly> weeklyOpt = weeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+        List<Record> records = weeklyOpt
+                .map(w -> recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(w.getId())))
+                .orElse(List.of());
 
-        List<Record> records = weeklyIds.isEmpty()
-                ? List.of()
-                : recordRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
-
-        GetRecordResponse.TodayRecordItem todayItem = records.stream()
-                .filter(r -> r.getCreatedAt().toLocalDate().equals(today))
-                .findFirst()
-                .map(r -> new GetRecordResponse.TodayRecordItem(r.getId(), nullToEmpty(r.getThumbnail())))
-                .orElse(null);
-
-        List<GetRecordResponse.WeeklyGroupItem> weekly = weekContexts.stream()
-                .map(wc -> buildWeeklyGroupItem(wc, records))
-                .toList();
-
-        return new GetRecordResponse(todayItem, weekly);
-    }
-
-    private GetRecordResponse.WeeklyGroupItem buildWeeklyGroupItem(WeekContext wc, List<Record> records) {
-        String title = wc.weeklyOpt()
-                .map(w -> w.getTitle() != null ? w.getTitle() : formatWeeklyTitle(wc.month(), wc.week()))
-                .orElse(formatWeeklyTitle(wc.month(), wc.week()));
-        List<GetRecordResponse.WeeklyRecordItem> items = records.stream()
-                .filter(r -> sameWeek(r, wc.year(), wc.month(), wc.week()))
+        List<GetRecordResponse.RecordItem> recordItems = records.stream()
+                .filter(r -> isDateInRange(r.getCreatedAt(), weekMonday, weekSunday))
                 .sorted(Comparator.comparing(Record::getCreatedAt).reversed())
-                .map(r -> new GetRecordResponse.WeeklyRecordItem(r.getId(), nullToEmpty(r.getThumbnail()), r.getCreatedAt()))
+                .map(this::toRecordItem)
                 .toList();
-        return new GetRecordResponse.WeeklyGroupItem(title, wc.year(), wc.month(), wc.week(), items);
+
+        return new GetRecordResponse(recordItems);
     }
 
-    private record WeekContext(int year, int month, int week, Optional<Weekly> weeklyOpt) {}
+    /** createdAt의 날짜가 [weekMonday, weekSunday] 안에 있는지 검사. 저장이 KST면 atZone(APP_ZONE), UTC면 UTC→Seoul 변환 필요. */
+    private static boolean isDateInRange(LocalDateTime createdAt, LocalDate weekMonday, LocalDate weekSunday) {
+        LocalDate d = createdAt.atZone(APP_ZONE).toLocalDate();
+        return !d.isBefore(weekMonday) && !d.isAfter(weekSunday);
+    }
+
+    private GetRecordResponse.RecordItem toRecordItem(Record record) {
+        List<GetRecordMusicDto> recordMusics = recordMusicRepository.findAllByRecordId(record.getId());
+        List<GetRecordResponse.MusicThumbnailItem> musics = recordMusics.stream()
+                .map(dto -> new GetRecordResponse.MusicThumbnailItem(nullToEmpty(dto.getThumbnail())))
+                .toList();
+        List<String> emotions = record.getEmotionsToString();
+        return new GetRecordResponse.RecordItem(
+                record.getId(),
+                record.getCreatedAt(),
+                musics,
+                emotions
+        );
+    }
 
     private static String nullToEmpty(String s) {
         return s != null ? s : "";
     }
 
-    private static String formatWeeklyTitle(int month, int week) {
-        return  month + "월 " + week + "주차";
-    }
-
-    private static boolean sameWeek(Record r, int year, int month, int week) {
-        Weekly w = r.getWeekly();
-        return w != null && w.getYear() == year && w.getMonth() == month && w.getWeek() == week;
-    }
-
     @Transactional
     public CreateRecordResponse createRecord(Long userId, CreateRecordCommand command) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
         LocalDateTime startOfDay = today.atStartOfDay();
         LocalDateTime startOfNextDay = today.plusDays(1).atStartOfDay();
 
@@ -208,18 +199,18 @@ public class RecordService {
 
     /**
      * 주차는 월요일 시작 ~ 일요일 끝.
-     * 오늘 날짜가 속한 주의 월요일 기준으로 (year, month, week) 계산.
+     * previousOrSame(MONDAY)로 주의 첫날(월요일)을 명시적으로 구해 (year, month, week) 계산.
      */
     private int getYearOfWeek(LocalDate date) {
-        return date.with(DayOfWeek.MONDAY).getYear();
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getYear();
     }
 
     private int getMonthOfWeek(LocalDate date) {
-        return date.with(DayOfWeek.MONDAY).getMonthValue();
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getMonthValue();
     }
 
     private int getWeekOfMonth(LocalDate date) {
-        LocalDate monday = date.with(DayOfWeek.MONDAY);
+        LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         return (monday.getDayOfMonth() - 1) / 7 + 1;
     }
 

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -29,7 +29,9 @@ import java.time.ZonedDateTime;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -63,10 +65,13 @@ public class RecordService {
 
     private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
 
+    private static final int DAYS_PER_WEEK = 7;
+
     /**
      * 이번 주(월요일~일요일)에 해당하는 userId의 records를 조회하여
-     * recordId, createdAt, musics(thumbnail), emotions 형태로 반환.
-     * 주의 시작은 월요일, 끝은 일요일. 기준 시간대는 Asia/Seoul.
+     * recordId, createdAt, musics, emotions, isToday 형태로 반환.
+     * - records는 항상 7개 (월~일 순). 기록 없는 날은 recordId/createdAt null, musics/emotions [], isToday만 해당 날짜 여부.
+     * 기준 시간대는 Asia/Seoul.
      */
     public GetRecordResponse getRecords(Long userId) {
         LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
@@ -82,13 +87,29 @@ public class RecordService {
                 .map(w -> recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(w.getId())))
                 .orElse(List.of());
 
-        List<GetRecordResponse.RecordItem> recordItems = records.stream()
-                .filter(r -> isDateInRange(r.getCreatedAt(), weekMonday, weekSunday))
-                .sorted(Comparator.comparing(Record::getCreatedAt).reversed())
-                .map(this::toRecordItem)
-                .toList();
+        Map<LocalDate, Record> recordByDate = new HashMap<>();
+        for (Record r : records) {
+            if (isDateInRange(r.getCreatedAt(), weekMonday, weekSunday)) {
+                LocalDate d = r.getCreatedAt().atZone(APP_ZONE).toLocalDate();
+                recordByDate.put(d, r);
+            }
+        }
+
+        List<GetRecordResponse.RecordItem> recordItems = new ArrayList<>(DAYS_PER_WEEK);
+        for (int i = 0; i < DAYS_PER_WEEK; i++) {
+            LocalDate day = weekMonday.plusDays(i);
+            Record record = recordByDate.get(day);
+            boolean isToday = day.equals(today);
+            recordItems.add(record != null
+                    ? toRecordItem(record, isToday)
+                    : emptyRecordItem(isToday));
+        }
 
         return new GetRecordResponse(recordItems);
+    }
+
+    private static GetRecordResponse.RecordItem emptyRecordItem(boolean isToday) {
+        return new GetRecordResponse.RecordItem(null, null, List.of(), List.of(), isToday);
     }
 
     /** createdAt의 날짜가 [weekMonday, weekSunday] 안에 있는지 검사. 저장이 KST면 atZone(APP_ZONE), UTC면 UTC→Seoul 변환 필요. */
@@ -97,7 +118,7 @@ public class RecordService {
         return !d.isBefore(weekMonday) && !d.isAfter(weekSunday);
     }
 
-    private GetRecordResponse.RecordItem toRecordItem(Record record) {
+    private GetRecordResponse.RecordItem toRecordItem(Record record, boolean isToday) {
         List<GetRecordMusicDto> recordMusics = recordMusicRepository.findAllByRecordId(record.getId());
         List<GetRecordResponse.MusicThumbnailItem> musics = recordMusics.stream()
                 .map(dto -> new GetRecordResponse.MusicThumbnailItem(nullToEmpty(dto.getThumbnail())))
@@ -107,7 +128,8 @@ public class RecordService {
                 record.getId(),
                 record.getCreatedAt(),
                 musics,
-                emotions
+                emotions,
+                isToday
         );
     }
 

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -18,13 +18,16 @@ import dalgrock.playlist.model.Weekly;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
 import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
-import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
+import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
+import dalgrock.playlist.service.dto.response.GetRecordResponse;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -53,6 +56,72 @@ public class RecordService {
                 .toList();
 
         return GetRecordDetailResponse.of(record, recordMusicResponses);
+    }
+
+    /**
+     * 오늘·7일 전·14일 전 주차의 (year, month, week)로 해당 userId의 records를 조회한 뒤,
+     * 이번주 → 7일 전 주 → 14일 전 주 순으로 응답을 가공하여 반환.
+     */
+    public GetRecordResponse getRecords(Long userId) {
+        LocalDate today = LocalDate.now();
+        List<LocalDate> weekDates = List.of(today, today.minusDays(7), today.minusDays(14));
+
+        List<WeekContext> weekContexts = weekDates.stream()
+                .map(d -> {
+                    int y = getYearOfWeek(d);
+                    int m = getMonthOfWeek(d);
+                    int w = getWeekOfMonth(d);
+                    return new WeekContext(y, m, w, weeklyRepository.findByYearAndMonthAndWeek(y, m, w));
+                })
+                .toList();
+
+        List<Long> weeklyIds = weekContexts.stream()
+                .flatMap(wc -> wc.weeklyOpt().stream())
+                .map(Weekly::getId)
+                .toList();
+
+        List<Record> records = weeklyIds.isEmpty()
+                ? List.of()
+                : recordRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
+
+        GetRecordResponse.TodayRecordItem todayItem = records.stream()
+                .filter(r -> r.getCreatedAt().toLocalDate().equals(today))
+                .findFirst()
+                .map(r -> new GetRecordResponse.TodayRecordItem(r.getId(), nullToEmpty(r.getThumbnail())))
+                .orElse(null);
+
+        List<GetRecordResponse.WeeklyGroupItem> weekly = weekContexts.stream()
+                .map(wc -> buildWeeklyGroupItem(wc, records))
+                .toList();
+
+        return new GetRecordResponse(todayItem, weekly);
+    }
+
+    private GetRecordResponse.WeeklyGroupItem buildWeeklyGroupItem(WeekContext wc, List<Record> records) {
+        String title = wc.weeklyOpt()
+                .map(w -> w.getTitle() != null ? w.getTitle() : formatWeeklyTitle(wc.month(), wc.week()))
+                .orElse(formatWeeklyTitle(wc.month(), wc.week()));
+        List<GetRecordResponse.WeeklyRecordItem> items = records.stream()
+                .filter(r -> sameWeek(r, wc.year(), wc.month(), wc.week()))
+                .sorted(Comparator.comparing(Record::getCreatedAt).reversed())
+                .map(r -> new GetRecordResponse.WeeklyRecordItem(r.getId(), nullToEmpty(r.getThumbnail()), r.getCreatedAt()))
+                .toList();
+        return new GetRecordResponse.WeeklyGroupItem(title, wc.year(), wc.month(), wc.week(), items);
+    }
+
+    private record WeekContext(int year, int month, int week, Optional<Weekly> weeklyOpt) {}
+
+    private static String nullToEmpty(String s) {
+        return s != null ? s : "";
+    }
+
+    private static String formatWeeklyTitle(int month, int week) {
+        return  month + "월 " + week + "주차";
+    }
+
+    private static boolean sameWeek(Record r, int year, int month, int week) {
+        Weekly w = r.getWeekly();
+        return w != null && w.getYear() == year && w.getMonth() == month && w.getWeek() == week;
     }
 
     @Transactional

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
@@ -5,18 +5,19 @@ import java.util.List;
 
 /**
  * GET /v1/records 응답.
- * - records: 이번 주 기록 배열 (recordId, createdAt, musics, emotions)
+ * - records: 항상 7개 (월~일 순, 늦은 날짜가 뒤). 기록 없는 날은 recordId/createdAt null, musics/emotions 빈 배열, isToday만 해당 날짜 여부.
  */
 public record GetRecordResponse(
         List<RecordItem> records
 ) {
 
-    /** 기록 한 건 (recordId, createdAt, musics, emotions) */
+    /** 기록 한 건 또는 빈 슬롯 (기록 없으면 recordId·createdAt null, musics·emotions 빈 배열, isToday로 오늘 여부 표시) */
     public record RecordItem(
             Long recordId,
             LocalDateTime createdAt,
             List<MusicThumbnailItem> musics,
-            List<String> emotions
+            List<String> emotions,
+            boolean isToday
     ) {}
 
     /** 음악 썸네일 (thumbnail) */

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
@@ -5,33 +5,22 @@ import java.util.List;
 
 /**
  * GET /v1/records 응답.
- * - today: 오늘 기록 1건 (없으면 null)
- * - weekly: 주차별 그룹 배열 (각 주차에 records 배열)
+ * - records: 이번 주 기록 배열 (recordId, createdAt, musics, emotions)
  */
 public record GetRecordResponse(
-        TodayRecordItem today,
-        List<WeeklyGroupItem> weekly
+        List<RecordItem> records
 ) {
 
-    /** 오늘 기록 1건 (recordId, thumbnail) */
-    public record TodayRecordItem(
+    /** 기록 한 건 (recordId, createdAt, musics, emotions) */
+    public record RecordItem(
             Long recordId,
+            LocalDateTime createdAt,
+            List<MusicThumbnailItem> musics,
+            List<String> emotions
+    ) {}
+
+    /** 음악 썸네일 (thumbnail) */
+    public record MusicThumbnailItem(
             String thumbnail
-    ) {}
-
-    /** 주차 한 덩어리 (title, year, month, week, records) */
-    public record WeeklyGroupItem(
-            String title,
-            int year,
-            int month,
-            int week,
-            List<WeeklyRecordItem> records
-    ) {}
-
-    /** 주차 내 기록 한 건 (recordId, thumbnail, createdAt) */
-    public record WeeklyRecordItem(
-            Long recordId,
-            String thumbnail,
-            LocalDateTime createdAt
     ) {}
 }

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetRecordResponse.java
@@ -1,0 +1,37 @@
+package dalgrock.playlist.service.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * GET /v1/records 응답.
+ * - today: 오늘 기록 1건 (없으면 null)
+ * - weekly: 주차별 그룹 배열 (각 주차에 records 배열)
+ */
+public record GetRecordResponse(
+        TodayRecordItem today,
+        List<WeeklyGroupItem> weekly
+) {
+
+    /** 오늘 기록 1건 (recordId, thumbnail) */
+    public record TodayRecordItem(
+            Long recordId,
+            String thumbnail
+    ) {}
+
+    /** 주차 한 덩어리 (title, year, month, week, records) */
+    public record WeeklyGroupItem(
+            String title,
+            int year,
+            int month,
+            int week,
+            List<WeeklyRecordItem> records
+    ) {}
+
+    /** 주차 내 기록 한 건 (recordId, thumbnail, createdAt) */
+    public record WeeklyRecordItem(
+            Long recordId,
+            String thumbnail,
+            LocalDateTime createdAt
+    ) {}
+}


### PR DESCRIPTION
## Issue Number
closed #15

## As-is
- 내 기록 목록을 주차별로 조회할 수 없었습니다.
- 오늘 기록과 이번 주·이전 주 기록을 한 번에 구분해 볼 수 없었습니다.

## To-be
- 내 기록 목록 조회 기능을 구현합니다.
- `GET /v1/records` 로 조회 시 JWT 인가된 사용자(`UserPrincipal.userId`) 기준으로, 요청 시점(Asia/Seoul) 기준 이번 주(월요일~일요일) 에 해당하는 기록만 조회합니다.
- 요청 시점 날짜로 해당 주의 (year, month, week)를 계산하고, Weekly 테이블에서 `findByYearAndMonthAndWeek` 로 해당 주차를 조회합니다. 주차가 없으면 빈 기록(7일 모두 recordId/createdAt null)으로 응답합니다.
- `Record`는 `userId` + 해당 주의 `weeklyId` 한 건으로 `RecordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(weeklyId))` 를 통해 한 번에 조회하며, `JpaRecordRepository`에서는 `@Query`로 `JOIN FETCH r.weekly` 를 사용해 N+1을 방지합니다.
- 응답은 `GetRecordResponse` 형태로 반환합니다.
  - records: 항상 7개 (월요일~일요일 순). 각 항목은 `recordId`, `createdAt`, `musics`(thumbnail), `emotions`, `isToday` 를 가집니다.
  - 해당 날짜에 기록이 없으면 `recordId`, `createdAt`은 null, `musics`, `emotions`는 빈 배열이며, `isToday`만 그 날이 오늘인지 표시합니다.
  - 기록이 있는 날만 실제 데이터를 채우고, 나머지는 위와 같은 빈 슬롯으로 채웁니다.
- Weekly 테이블에 (year, month, week) unique 제약을 두어 동일 주차 중복 행을 방지합니다.
- 인가 시 UserPrincipal 로 사용자 정보를 받아 해당 사용자 소유 기록만 조회합니다.
- getRecords 내부에서는 요청 시점 기준 이번 주 월~일 7일을 구한 뒤, 해당 주차의 Record 목록을 조회하고 날짜별로 매핑하여 7개 RecordItem을 채우는 방식으로 주차·날짜 로직을 한 곳에서 처리해 가독성을 높였습니다.


## Additional Description
- `RecordRepository`에 `findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds)` 를 추가했고, `JpaRecordRepository`에서는 `findByUserIdAndWeeklyIdInFetchWeekly` 메서드에 `@Query("SELECT r FROM records r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds")` 를 사용해 N+1을 제거했습니다.
- `RecordRepositoryAdapter`에서 포트 메서드 `findByUserIdAndWeeklyIdIn` 구현 시 위 JPQL 메서드를 호출하도록 연결했습니다.