### PR TITLE
주차별 기록 조회

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/WeeklyControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/WeeklyControllerV1.java
@@ -1,0 +1,38 @@
+package dalgrock.playlist.controller;
+
+import dalgrock.playlist.model.UserPrincipal;
+import dalgrock.playlist.service.WeeklyService;
+import dalgrock.playlist.service.dto.response.GetWeeklyResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Weekly", description = "주차별 기록 조회 API")
+@Validated
+@SecurityRequirement(name = "cookieAuth")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/weekly")
+public class WeeklyControllerV1 {
+
+    private final WeeklyService weeklyService;
+
+    @Operation(summary = "주차별 기록 조회", description = "year, month 기준 해당 달의 주차별 레코드를 조회합니다")
+    @GetMapping
+    public GetWeeklyResponse getWeeklyRecords(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam @Min(1900) @Max(2100) int year,
+            @RequestParam @Min(1) @Max(12) int month
+    ) {
+        return weeklyService.getWeeklyRecords(principal.userId(), year, month);
+    }
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/WeeklyRepository.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.model.Weekly;
+import java.util.List;
 import java.util.Optional;
 
 public interface WeeklyRepository {
@@ -8,6 +9,8 @@ public interface WeeklyRepository {
     Optional<Weekly> findById(Long id);
 
     Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week);
+
+    List<Weekly> findByYearAndMonth(int year, int month);
 
     Weekly save(Weekly weekly);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaWeeklyRepository.java
@@ -1,10 +1,13 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Weekly;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaWeeklyRepository extends JpaRepository<Weekly, Long> {
 
     Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week);
+
+    List<Weekly> findByYearAndMonthOrderByWeekAsc(int year, int month);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/WeeklyRepositoryAdapter.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
 import dalgrock.playlist.model.Weekly;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,6 +21,11 @@ public class WeeklyRepositoryAdapter implements WeeklyRepository {
     @Override
     public Optional<Weekly> findByYearAndMonthAndWeek(int year, int month, int week) {
         return jpaWeeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+    }
+
+    @Override
+    public List<Weekly> findByYearAndMonth(int year, int month) {
+        return jpaWeeklyRepository.findByYearAndMonthOrderByWeekAsc(year, month);
     }
 
     @Override

--- a/src/main/java/dalgrock/playlist/service/WeeklyService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyService.java
@@ -1,0 +1,58 @@
+package dalgrock.playlist.service;
+
+import dalgrock.playlist.infrastructure.repository.RecordRepository;
+import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
+import dalgrock.playlist.model.Record;
+import dalgrock.playlist.model.Weekly;
+import dalgrock.playlist.service.dto.response.GetWeeklyResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class WeeklyService {
+
+    private final WeeklyRepository weeklyRepository;
+    private final RecordRepository recordRepository;
+
+    /**
+     * year, month에 해당하는 주차별 레코드를 userId 기준으로 조회.
+     */
+    public GetWeeklyResponse getWeeklyRecords(Long userId, int year, int month) {
+        List<Weekly> weeklies = weeklyRepository.findByYearAndMonth(year, month);
+        if (weeklies.isEmpty()) {
+            return new GetWeeklyResponse(year, month, List.of());
+        }
+
+        List<Long> weeklyIds = weeklies.stream().map(Weekly::getId).toList();
+        List<Record> allRecords = recordRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
+        Map<Long, List<Record>> recordsByWeeklyId = allRecords.stream()
+                .collect(Collectors.groupingBy(r -> r.getWeekly().getId()));
+
+        List<GetWeeklyResponse.WeeklyItem> weeklyItems = new ArrayList<>();
+        for (Weekly w : weeklies) {
+            List<Record> records = recordsByWeeklyId.getOrDefault(w.getId(), List.of());
+            List<GetWeeklyResponse.RecordItem> recordItems = records.stream()
+                    .sorted(Comparator.comparing(Record::getCreatedAt))
+                    .map(record -> toRecordItem(record))
+                    .toList();
+            weeklyItems.add(new GetWeeklyResponse.WeeklyItem(w.getWeek(), recordItems));
+        }
+
+        return new GetWeeklyResponse(year, month, weeklyItems);
+    }
+
+    private GetWeeklyResponse.RecordItem toRecordItem(Record record) {
+        String thumbnail = record.getThumbnail() != null ? record.getThumbnail() : "";
+        return new GetWeeklyResponse.RecordItem(
+                record.getId(),
+                record.getCreatedAt(),
+                thumbnail
+        );
+    }
+}

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetWeeklyResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetWeeklyResponse.java
@@ -1,0 +1,26 @@
+package dalgrock.playlist.service.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * GET /v1/weekly 응답.
+ * year, month 기준 해당 달의 주차별 레코드 목록.
+ */
+public record GetWeeklyResponse(
+        int year,
+        int month,
+        List<WeeklyItem> weekly
+) {
+
+    public record WeeklyItem(
+            int week,
+            List<RecordItem> records
+    ) {}
+
+    public record RecordItem(
+            Long recordId,
+            LocalDateTime createdAt,
+            String thumbnail
+    ) {}
+}


### PR DESCRIPTION
## Issue Number
closed #18

## As-is
- year, month 기준 해당 달의 주차별 기록을 조회할 수 없었습니다.
- 월별 기록을 주차 단위로 구분해 볼 수 없었습니다.

## To-be
- 주차별 기록 조회 기능을 구현합니다.
- `GET /v1/weekly` 로 조회 시 JWT 인가된 사용자(`UserPrincipal.userId`) 기준으로, `year`, `month` 파라미터에 해당하는 달의 주차별 레코드를 조회합니다.
- `Weekly` 테이블에서 `findByYearAndMonth(year, month)` 로 해당 달의 주차 목록을 조회합니다. 주차가 없으면 빈 `weekly` 배열로 응답합니다.
- `Record`는 `userId` + 해당 달의 `weeklyId` 목록으로 `RecordRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds)` 를 한 번만 호출해 조회하며, `JpaRecordRepository`의 `JOIN FETCH r.weekly` 로 N+1을 방지합니다.
- 응답은 `GetWeeklyResponse` 형태로 반환합니다.
  - **year**, **month**: 요청 파라미터 그대로 반환
  - **weekly**: 주차별 그룹 배열. 각 항목은 `week`, `records` 를 가집니다.
  - **records**: 해당 주차의 레코드 배열. `recordId`, `createdAt`, `thumbnail` 를 포함하며, `createdAt` 기준 날짜순 정렬입니다.
- `year`는 1900~2100, `month`는 1~12 범위로 `@Min`/`@Max` 검증을 적용합니다.
- 인가 시 UserPrincipal 로 사용자 정보를 받아 해당 사용자 소유 기록만 조회합니다.

## Additional Description
- `WeeklyRepository`에 `findByYearAndMonth(int year, int month)` 를 추가했고, `JpaWeeklyRepository`에서는 `findByYearAndMonthOrderByWeekAsc` 로 주차 오름차순 정렬하여 조회합니다.
- `WeeklyRepositoryAdapter`에서 포트 메서드 `findByYearAndMonth` 구현 시 위 메서드를 호출하도록 연결했습니다.
- `WeeklyControllerV1`, `WeeklyService`, `GetWeeklyResponse` 를 추가했습니다.