### PR TITLE
기록 수정/삭제

### DIFF
--- a/src/main/java/dalgrock/playlist/config/SecurityConfig.java
+++ b/src/main/java/dalgrock/playlist/config/SecurityConfig.java
@@ -3,11 +3,13 @@ package dalgrock.playlist.config;
 import dalgrock.playlist.core.jwt.JwtAuthenticationFilter;
 import dalgrock.playlist.core.jwt.JwtTokenProvider;
 import dalgrock.playlist.service.CustomOAuth2UserService;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,6 +30,9 @@ public class SecurityConfig {
     @Value("${app.auth.host}")
     private String baseUrl;
 
+    @Value("${app.cors.allowed-origins:}")
+    private String corsAllowedOriginsStr;
+
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
@@ -36,7 +41,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowedOrigins(List.of(baseUrl));
+        List<String> origins = (corsAllowedOriginsStr != null && !corsAllowedOriginsStr.isBlank())
+                ? Arrays.stream(corsAllowedOriginsStr.split(",")).map(String::trim).filter(s -> !s.isEmpty()).toList()
+                : List.of(baseUrl);
+        config.setAllowedOrigins(origins);
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
         config.setAllowedHeaders(List.of("*"));
         config.setAllowCredentials(true);
@@ -55,6 +63,7 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception.authenticationEntryPoint(
                         new HttpStatusEntryPoint(HttpStatus.UNAUTHORIZED)))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                         .requestMatchers("/", "/api-docs/**", "/swagger-ui/**").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/login-test.html", "/oauth-callback.html", "/test/**").permitAll()

--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -7,9 +7,11 @@ import dalgrock.playlist.service.RecordService;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
 import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
 import dalgrock.playlist.service.dto.command.UpdateRecordCommand;
+import dalgrock.playlist.service.WeeklyService;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import dalgrock.playlist.service.dto.response.GetRecordResponse;
+import dalgrock.playlist.service.dto.response.GetWeeklyResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
@@ -17,6 +19,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -30,11 +34,14 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RestController;
 import tools.jackson.databind.JsonNode;
 
 @Tag(name = "Record", description = "내 기록 관리 API")
+@Validated
 @SecurityRequirement(name = "cookieAuth")
 @RequiredArgsConstructor
 @RestController
@@ -42,6 +49,7 @@ import tools.jackson.databind.JsonNode;
 public class RecordControllerV1 {
 
     private final RecordService recordService;
+    private final WeeklyService weeklyService;
 
     @Operation(summary = "내 기록 상세 조회", description = "내 기록 ID로 기록을 상세 조회합니다")
     @GetMapping("/detail/{recordId}")
@@ -85,6 +93,16 @@ public class RecordControllerV1 {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         return recordService.getRecords(principal.userId());
+    }
+
+    @Operation(summary = "주차별 기록 조회", description = "year, month 기준 해당 달의 주차별 레코드를 조회합니다")
+    @GetMapping("/monthly")
+    public GetWeeklyResponse getMonthlyRecords(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam @Min(1900) @Max(2100) int year,
+            @RequestParam @Min(1) @Max(12) int month
+    ) {
+        return weeklyService.getWeeklyRecords(principal.userId(), year, month);
     }
 
     @Operation(

--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -1,28 +1,38 @@
 package dalgrock.playlist.controller;
 
 import dalgrock.playlist.controller.dto.request.CreateRecordRequest;
+import dalgrock.playlist.controller.dto.request.UpdateRecordRequest;
 import dalgrock.playlist.model.UserPrincipal;
 import dalgrock.playlist.service.RecordService;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
 import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
+import dalgrock.playlist.service.dto.command.UpdateRecordCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import dalgrock.playlist.service.dto.response.GetRecordResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import tools.jackson.databind.JsonNode;
 
 @Tag(name = "Record", description = "내 기록 관리 API")
 @SecurityRequirement(name = "cookieAuth")
@@ -75,5 +85,104 @@ public class RecordControllerV1 {
             @AuthenticationPrincipal UserPrincipal principal
     ) {
         return recordService.getRecords(principal.userId());
+    }
+
+    @Operation(
+            summary = "내 기록 수정",
+            description = """
+                    type에 해당하는 필드만 수정합니다. 한 번에 하나의 필드만 수정 가능합니다.
+                    
+                    **type별 data 스키마:**
+                    | type | data 스키마 | 예시 |
+                    |------|-------------|------|
+                    | content | string | `"오늘의 기록 내용"` |
+                    | emotions | string[] | `["행복", "설렘"]` |
+                    | situations | string[] | `["출퇴근", "카페"]` |
+                    | musics | object[] | `[{ "title": "곡명", "artist": "아티스트", "thumbnail": "https://..." }]` |
+                    
+                    musics 수정 시: Music 테이블에 없으면 추가하고, record 썸네일은 첫 곡 썸네일로 갱신됩니다.
+                    """,
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = UpdateRecordRequest.class),
+                            examples = {
+                                    @ExampleObject(name = "content 수정", value = "{\"type\":\"content\",\"data\":\"오늘의 기록 내용입니다.\"}"),
+                                    @ExampleObject(name = "emotions 수정", value = "{\"type\":\"emotions\",\"data\":[\"행복\",\"설렘\",\"평온\"]}"),
+                                    @ExampleObject(name = "situations 수정", value = "{\"type\":\"situations\",\"data\":[\"출퇴근\",\"카페\"]}"),
+                                    @ExampleObject(name = "musics 수정", value = "{\"type\":\"musics\",\"data\":[{\"title\":\"곡제목\",\"artist\":\"아티스트명\",\"thumbnail\":\"https://example.com/thumb.png\"}]}")
+                            }
+                    )
+            )
+    )
+    @PatchMapping("/{recordId}")
+    public GetRecordDetailResponse updateRecord(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("recordId") Long recordId,
+            @RequestBody @Valid UpdateRecordRequest request
+    ) {
+        UpdateRecordCommand command = toUpdateCommand(request);
+        return recordService.updateRecord(principal.userId(), recordId, command);
+    }
+
+    @Operation(summary = "내 기록 삭제", description = "기록을 소프트 삭제합니다")
+    @DeleteMapping("/{recordId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void deleteRecord(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @PathVariable("recordId") Long recordId
+    ) {
+        recordService.deleteRecord(principal.userId(), recordId);
+    }
+
+    private UpdateRecordCommand toUpdateCommand(UpdateRecordRequest request) {
+        String type = request.type().toLowerCase();
+        JsonNode data = request.data();
+
+        return switch (type) {
+            case "content" -> {
+                if (data.isArray() || data.isObject()) {
+                    throw new IllegalArgumentException("content type requires string data");
+                }
+                yield new UpdateRecordCommand(type, null, null, null, data.asText(null));
+            }
+            case "emotions" -> new UpdateRecordCommand(
+                    type, null,
+                    data.isArray() ? parseStringList(data) : List.of(),
+                    null, null
+            );
+            case "situations" -> new UpdateRecordCommand(
+                    type, null, null,
+                    data.isArray() ? parseStringList(data) : List.of(),
+                    null
+            );
+            case "musics" -> new UpdateRecordCommand(
+                    type,
+                    data.isArray() ? parseMusicList(data) : List.of(),
+                    null, null, null
+            );
+            default -> throw new IllegalArgumentException("Invalid update type: " + type);
+        };
+    }
+
+    private List<String> parseStringList(JsonNode arr) {
+        List<String> result = new ArrayList<>();
+        arr.forEach(node -> result.add(node.asText()));
+        return result;
+    }
+
+    private List<CreateRecordMusicCommand> parseMusicList(JsonNode arr) {
+        List<CreateRecordMusicCommand> result = new ArrayList<>();
+        arr.forEach(node -> {
+            if (!node.isObject()) {
+                throw new IllegalArgumentException("musics type requires array of objects");
+            }
+            result.add(new CreateRecordMusicCommand(
+                    node.has("title") ? node.get("title").asText() : "",
+                    node.has("artist") ? node.get("artist").asText() : "",
+                    node.has("thumbnail") ? node.get("thumbnail").asText(null) : null
+            ));
+        });
+        return result;
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/WeeklyControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/WeeklyControllerV1.java
@@ -16,12 +16,12 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-@Tag(name = "Weekly", description = "주차별 기록 조회 API")
+@Tag(name = "Weekly", description = "월별 기록 조회 API")
 @Validated
 @SecurityRequirement(name = "cookieAuth")
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/v1/weekly")
+@RequestMapping("/v1/reports/monthly")
 public class WeeklyControllerV1 {
 
     private final WeeklyService weeklyService;

--- a/src/main/java/dalgrock/playlist/controller/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/dalgrock/playlist/controller/dto/request/UpdateRecordRequest.java
@@ -1,0 +1,38 @@
+package dalgrock.playlist.controller.dto.request;
+
+import tools.jackson.databind.JsonNode;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+@Schema(
+        description = "기록 수정 요청. type에 따라 data 스키마가 달라집니다. 한 번에 하나의 필드만 수정 가능합니다.",
+        requiredProperties = {"type", "data"}
+)
+public record UpdateRecordRequest(
+        @NotBlank(message = "type is required")
+        @Pattern(regexp = "^(content|emotions|situations|musics)$", message = "type must be one of: content, emotions, situations, musics")
+        @Schema(
+                description = "수정할 필드 타입",
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                allowableValues = {"content", "emotions", "situations", "musics"},
+                example = "content"
+        )
+        String type,
+
+        @NotNull(message = "data is required")
+        @Schema(
+                description = """
+                        type에 따른 data 스키마:
+                        - **content**: string (기록 본문)
+                        - **emotions**: string[] (감정 목록)
+                        - **situations**: string[] (상황 목록)
+                        - **musics**: object[] (음악 목록, 각 항목: { title, artist, thumbnail })
+                        """,
+                requiredMode = Schema.RequiredMode.REQUIRED,
+                example = "오늘의 기록 내용"
+        )
+        JsonNode data
+) {
+}

--- a/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
+++ b/src/main/java/dalgrock/playlist/controller/exception/GlobalExceptionHandler.java
@@ -29,6 +29,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
     }
 
+    @ExceptionHandler(IllegalArgumentException.class)
+    protected ResponseEntity<ErrorResponse> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException: {}", e.getMessage());
+        ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(Exception.class)
     protected ResponseEntity<ErrorResponse> handleException(Exception e) {
         log.error("Internal Server Error: ", e);

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordMusicRepository.java
@@ -11,4 +11,6 @@ public interface RecordMusicRepository {
     RecordMusic save(RecordMusic recordMusic);
 
     List<RecordMusic> saveAll(List<RecordMusic> recordMusics);
+
+    void deleteByRecordId(Long recordId);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordMusicRepository.java
@@ -17,4 +17,6 @@ public interface JpaRecordMusicRepository extends JpaRepository<RecordMusic, Lon
             where rm.record_id = :recordId
             """, nativeQuery = true)
     List<GetRecordMusicDto> findAllByRecordId(@Param("recordId") Long recordId);
+
+    void deleteByRecordId(Long recordId);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
@@ -9,8 +9,10 @@ import org.springframework.data.repository.query.Param;
 
 public interface JpaRecordRepository extends JpaRepository<Record, Long> {
 
-    boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+    boolean existsByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(Long userId, LocalDateTime start, LocalDateTime end);
 
-    @Query("SELECT r FROM records r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds")
+    @Query("SELECT r FROM records r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds AND r.deletedAt IS NULL")
     List<Record> findByUserIdAndWeeklyIdInFetchWeekly(@Param("userId") Long userId, @Param("weeklyIds") List<Long> weeklyIds);
+
+    java.util.Optional<Record> findByIdAndDeletedAtIsNull(Long id);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordMusicRepositoryAdapter.java
@@ -27,4 +27,9 @@ public class RecordMusicRepositoryAdapter implements RecordMusicRepository {
     public List<RecordMusic> saveAll(List<RecordMusic> recordMusics) {
         return jpaRecordMusicRepository.saveAll(recordMusics);
     }
+
+    @Override
+    public void deleteByRecordId(Long recordId) {
+        jpaRecordMusicRepository.deleteByRecordId(recordId);
+    }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
@@ -16,7 +16,7 @@ public class RecordRepositoryAdapter implements RecordRepository {
 
     @Override
     public Optional<Record> findById(Long id) {
-        return jpaRecordRepository.findById(id);
+        return jpaRecordRepository.findByIdAndDeletedAtIsNull(id);
     }
 
     @Override
@@ -26,7 +26,7 @@ public class RecordRepositoryAdapter implements RecordRepository {
 
     @Override
     public boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end) {
-        return jpaRecordRepository.existsByUserIdAndCreatedAtBetween(userId, start, end);
+        return jpaRecordRepository.existsByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId, start, end);
     }
 
     @Override

--- a/src/main/java/dalgrock/playlist/model/Record.java
+++ b/src/main/java/dalgrock/playlist/model/Record.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -60,6 +61,9 @@ public class Record extends BaseTimeEntity {
     @JoinColumn(name = "weekly_id", nullable = false)
     private Weekly weekly;
 
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public List<String> getEmotionsToString() {
         return this.emotions.stream()
                 .map(Emotion::getValue)
@@ -70,5 +74,27 @@ public class Record extends BaseTimeEntity {
         return this.situations.stream()
                 .map(Situation::getValue)
                 .toList();
+    }
+
+    public void updateContent(String content) {
+        this.content = content;
+    }
+
+    public void updateEmotions(List<Emotion> emotions) {
+        this.emotions.clear();
+        this.emotions.addAll(emotions);
+    }
+
+    public void updateSituations(List<Situation> situations) {
+        this.situations.clear();
+        this.situations.addAll(situations);
+    }
+
+    public void updateThumbnail(String thumbnail) {
+        this.thumbnail = thumbnail != null ? thumbnail : "";
+    }
+
+    public void softDelete(LocalDateTime deletedAt) {
+        this.deletedAt = deletedAt;
     }
 }

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -17,6 +17,7 @@ import dalgrock.playlist.model.Situation;
 import dalgrock.playlist.model.Weekly;
 import dalgrock.playlist.service.dto.command.CreateRecordCommand;
 import dalgrock.playlist.service.dto.command.CreateRecordMusicCommand;
+import dalgrock.playlist.service.dto.command.UpdateRecordCommand;
 import dalgrock.playlist.service.dto.response.CreateRecordResponse;
 import dalgrock.playlist.service.dto.response.GetRecordDetailResponse;
 import dalgrock.playlist.service.dto.response.GetRecordMusicResponse;
@@ -247,5 +248,74 @@ public class RecordService {
                             .build();
                     return weeklyRepository.save(newWeekly);
                 });
+    }
+
+    @Transactional
+    public GetRecordDetailResponse updateRecord(Long userId, Long recordId, UpdateRecordCommand command) {
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new RecordNotFoundException(ErrorCode.RECORD_NOT_FOUND.getMessage()));
+
+        if (!record.getUserId().equals(userId)) {
+            throw new UnauthorizedException(ErrorCode.FORBIDDEN.getMessage());
+        }
+
+        switch (command.type().toLowerCase()) {
+            case "musics" -> updateMusics(record, command.musics());
+            case "emotions" -> updateEmotions(record, command.emotions());
+            case "situations" -> updateSituations(record, command.situations());
+            case "content" -> updateContent(record, command.content());
+            default -> throw new IllegalArgumentException("Invalid update type: " + command.type());
+        }
+
+        Record savedRecord = recordRepository.save(record);
+        List<GetRecordMusicDto> recordMusics = recordMusicRepository.findAllByRecordId(savedRecord.getId());
+        List<GetRecordMusicResponse> recordMusicResponses = recordMusics.stream()
+                .map(GetRecordMusicResponse::from)
+                .toList();
+        return GetRecordDetailResponse.of(savedRecord, recordMusicResponses);
+    }
+
+    private void updateMusics(Record record, List<CreateRecordMusicCommand> musics) {
+        if (musics == null || musics.isEmpty()) {
+            record.updateThumbnail("");
+            recordMusicRepository.deleteByRecordId(record.getId());
+            return;
+        }
+        recordMusicRepository.deleteByRecordId(record.getId());
+        String thumbnail = musics.get(0).thumbnail() != null ? musics.get(0).thumbnail() : "";
+        for (CreateRecordMusicCommand musicCommand : musics) {
+            Music music = findOrCreateMusic(musicCommand);
+            RecordMusic recordMusic = RecordMusic.builder()
+                    .recordId(record.getId())
+                    .musicId(music.getId())
+                    .build();
+            recordMusicRepository.save(recordMusic);
+        }
+        record.updateThumbnail(thumbnail);
+    }
+
+    private void updateEmotions(Record record, List<String> emotions) {
+        record.updateEmotions(toEmotions(emotions != null ? emotions : List.of()));
+    }
+
+    private void updateSituations(Record record, List<String> situations) {
+        record.updateSituations(toSituations(situations != null ? situations : List.of()));
+    }
+
+    private void updateContent(Record record, String content) {
+        record.updateContent(content != null ? content : "");
+    }
+
+    @Transactional
+    public void deleteRecord(Long userId, Long recordId) {
+        Record record = recordRepository.findById(recordId)
+                .orElseThrow(() -> new RecordNotFoundException(ErrorCode.RECORD_NOT_FOUND.getMessage()));
+
+        if (!record.getUserId().equals(userId)) {
+            throw new UnauthorizedException(ErrorCode.FORBIDDEN.getMessage());
+        }
+
+        record.softDelete(LocalDateTime.now());
+        recordRepository.save(record);
     }
 }

--- a/src/main/java/dalgrock/playlist/service/dto/command/UpdateRecordCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/UpdateRecordCommand.java
@@ -1,0 +1,12 @@
+package dalgrock.playlist.service.dto.command;
+
+import java.util.List;
+
+public record UpdateRecordCommand(
+        String type,
+        List<CreateRecordMusicCommand> musics,
+        List<String> emotions,
+        List<String> situations,
+        String content
+) {
+}

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetWeeklyResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetWeeklyResponse.java
@@ -4,7 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 /**
- * GET /v1/weekly 응답.
+ * GET /v1/records/monthly 응답.
  * year, month 기준 해당 달의 주차별 레코드 목록.
  */
 public record GetWeeklyResponse(

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -1,8 +1,8 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:5432/playlist
-    username: playlist2026
-    password: Playlist2026!
+    url: jdbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${POSTGRES_DB:playlist}
+    username: ${POSTGRES_USER:playlist2026}
+    password: ${POSTGRES_PASSWORD:Playlist2026!}
 
   jpa:
     hibernate:
@@ -61,7 +61,7 @@ app:
     secure-cookie: false
     samesite-cookie: None
   cors:
-    allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://127.0.0.1:8080"
+    allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,http://127.0.0.1:8080"
 
 spotify:
   client-id: ${SPOTIFY_CLIENT_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -74,7 +74,7 @@ app:
     secure-cookie: false
     samesite-cookie: None
   cors:
-    allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://127.0.0.1:8080"
+    allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,http://127.0.0.1:8080"
 
 logging:
   level:

--- a/src/main/resources/db/add-deleted-at-to-records.sql
+++ b/src/main/resources/db/add-deleted-at-to-records.sql
@@ -1,0 +1,2 @@
+-- Add deleted_at column for soft delete (run manually if needed)
+ALTER TABLE records ADD COLUMN IF NOT EXISTS deleted_at TIMESTAMP;


### PR DESCRIPTION
## Issue Number
closed #20 20

##As-is

- 기록을 수정할 수 없었습니다.
- 기록을 삭제할 수 없었습니다.
- 월별 주차별 기록 조회가 Record API와 분리되어 있어, 기록 관련 조회·수정·삭제가 한 곳에 모여 있지 않았습니다.
- 

## To-be

- 기록 수정 기능을 구현합니다.
- PATCH /v1/records/{recordId} 로 JWT 인가된 사용자(UserPrincipal.userId) 소유 기록만 수정합니다.
- 요청 Body는 UpdateRecordRequest(필드: type, data)이며, 한 번에 하나의 필드만 수정 가능합니다.
- type: content | emotions | situations | musics. data는 type별로 string / string[] / object[] 입니다.
- content: 기록 본문 문자열. emotions/situations: 문자열 배열. musics: { title, artist, thumbnail } 객체 배열이며, 없으면 Music 추가 후 record 썸네일은 첫 곡 썸네일로 갱신합니다.
- 응답은 수정된 기록 상세 GetRecordDetailResponse로 반환합니다.
- 기록 삭제 기능을 구현합니다.
- DELETE /v1/records/{recordId} 로 JWT 인가된 사용자 소유 기록만 삭제합니다.
- 소프트 삭제를 적용하며, Record.deletedAt에 삭제 시각을 저장합니다.
- 응답은 204 No Content이며, 이후 해당 record는 조회 대상에서 제외됩니다.
- 월별 주차별 기록 조회 경로를 정리합니다.
- GET /v1/records/monthly?year=&month= 를 추가하여, RecordController에서 기존 주차별 조회 로직(WeeklyService.getWeeklyRecords)을 사용합니다. year 1900~2100, month 1~12 에 @Min/@Max 검증을 적용합니다.
- WeeklyControllerV1 의 경로를 /v1/weekly 에서 /v1/reports/monthly 로 변경하고, Tag 설명을 "월별 기록 조회 API"로 수정합니다.
- Record 조회 시 deletedAt IS NULL 인 레코드만 조회하도록 Repository/Query를 적용합니다.

## Additional Description

- Record 엔티티에 deletedAt 컬럼을 추가하고 softDelete(LocalDateTime) 메서드를 두었습니다.
- add-deleted-at-to-records.sql 로 기존 records 테이블에 deleted_at 컬럼을 추가했습니다.
- UpdateRecordRequest(controller), UpdateRecordCommand(service)를 추가하고, RecordControllerV1에서 type별로 command 변환 후 RecordService.updateRecord를 호출합니다.
- RecordService.updateRecord는 소유자 검증 후 type에 따라 content/emotions/situations/musics만 갱신하며, musics 수정 시 기존 record_musics 삭제 후 재등록·썸네일 갱신을 수행합니다.
- RecordService.deleteRecord는 소유자 검증 후 record.softDelete(now) 및 save를 수행합니다.
- JpaRecordRepository 등 record 조회 쿼리에 r.deletedAt IS NULL 조건을 넣어 삭제된 기록이 목록·상세·주차별 조회에 포함되지 않도록 했습니다.
- RecordControllerV1에 WeeklyService 의존성을 추가하고 GET /monthly 핸들러를 두었으며, @Validated를 적용해 year/month 검증이 동작하도록 했습니다.
- GetWeeklyResponse 주석의 응답 경로를 GET /v1/records/monthly 기준으로 수정했습니다.