### PR TITLE
장르 추가

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -76,7 +76,8 @@ public class RecordControllerV1 {
                 .map(m -> new CreateRecordMusicCommand(
                         m.title(),
                         m.artist(),
-                        m.thumbnail()
+                        m.thumbnail(),
+                        m.genre()
                 ))
                 .collect(Collectors.toList());
         return new CreateRecordCommand(
@@ -116,7 +117,7 @@ public class RecordControllerV1 {
                     | content | string | `"오늘의 기록 내용"` |
                     | emotions | string[] | `["행복", "설렘"]` |
                     | situations | string[] | `["출퇴근", "카페"]` |
-                    | musics | object[] | `[{ "title": "곡명", "artist": "아티스트", "thumbnail": "https://..." }]` |
+                    | musics | object[] | `[{ "title": "곡명", "artist": "아티스트", "thumbnail": "https://...", "genre": "팝" }]` |
                     
                     musics 수정 시: Music 테이블에 없으면 추가하고, record 썸네일은 첫 곡 썸네일로 갱신됩니다.
                     """,
@@ -128,7 +129,7 @@ public class RecordControllerV1 {
                                     @ExampleObject(name = "content 수정", value = "{\"type\":\"content\",\"data\":\"오늘의 기록 내용입니다.\"}"),
                                     @ExampleObject(name = "emotions 수정", value = "{\"type\":\"emotions\",\"data\":[\"행복\",\"설렘\",\"평온\"]}"),
                                     @ExampleObject(name = "situations 수정", value = "{\"type\":\"situations\",\"data\":[\"출퇴근\",\"카페\"]}"),
-                                    @ExampleObject(name = "musics 수정", value = "{\"type\":\"musics\",\"data\":[{\"title\":\"곡제목\",\"artist\":\"아티스트명\",\"thumbnail\":\"https://example.com/thumb.png\"}]}")
+                                    @ExampleObject(name = "musics 수정", value = "{\"type\":\"musics\",\"data\":[{\"title\":\"곡제목\",\"artist\":\"아티스트명\",\"thumbnail\":\"https://example.com/thumb.png\",\"genre\":\"팝\"}]}"),
                             }
                     )
             )
@@ -198,7 +199,8 @@ public class RecordControllerV1 {
             result.add(new CreateRecordMusicCommand(
                     node.has("title") ? node.get("title").asText() : "",
                     node.has("artist") ? node.get("artist").asText() : "",
-                    node.has("thumbnail") ? node.get("thumbnail").asText(null) : null
+                    node.has("thumbnail") ? node.get("thumbnail").asText(null) : null,
+                    node.has("genre") ? node.get("genre").asText(null) : null
             ));
         });
         return result;

--- a/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
+++ b/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
@@ -27,7 +27,9 @@ public record CreateRecordRequest(
             @NotNull
             String artist,
 
-            String thumbnail
+            String thumbnail,
+
+            String genre
     ) {
     }
 }

--- a/src/main/java/dalgrock/playlist/controller/dto/request/UpdateRecordRequest.java
+++ b/src/main/java/dalgrock/playlist/controller/dto/request/UpdateRecordRequest.java
@@ -28,7 +28,7 @@ public record UpdateRecordRequest(
                         - **content**: string (기록 본문)
                         - **emotions**: string[] (감정 목록)
                         - **situations**: string[] (상황 목록)
-                        - **musics**: object[] (음악 목록, 각 항목: { title, artist, thumbnail })
+                        - **musics**: object[] (음악 목록, 각 항목: { title, artist, thumbnail, genre })
                         """,
                 requiredMode = Schema.RequiredMode.REQUIRED,
                 example = "오늘의 기록 내용"

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -215,7 +215,7 @@ public class RecordService {
                             .artist(artist)
                             .title(title)
                             .thumbnail(command.thumbnail() != null ? command.thumbnail() : "")
-                            .genre(null)
+                            .genre(command.genre() != null ? command.genre() : "")
                             .build();
                     return musicRepository.save(newMusic);
                 });

--- a/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordMusicCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordMusicCommand.java
@@ -3,6 +3,7 @@ package dalgrock.playlist.service.dto.command;
 public record CreateRecordMusicCommand(
         String title,
         String artist,
-        String thumbnail
+        String thumbnail,
+        String genre
 ) {
 }


### PR DESCRIPTION
## Issue Number
closed #29

## As-is

- 음악(music)에 장르(genre) 정보를 저장할 수 없었습니다.
- 기록 생성/수정 시 musics 배열 항목은 `title`, `artist`, `thumbnail` 만 지원했습니다.

## To-be

- 음악(music)에만 장르(genre) 필드를 추가합니다. (기록(record) 단위 장르 수정은 없습니다.)
- **기록 생성 (POST /v1/records)**  
  - 요청 body의 `musics` 배열 각 항목에 선택 필드 `genre`(string)를 넣을 수 있습니다.
- **기록 수정 (PATCH /v1/records/{recordId}, type: musics)**  
  - `data` 배열 각 항목에 `genre`(string)를 넣을 수 있습니다.
- Music 엔티티에 `genre`가 저장되며, 새 곡 추가 시에만 반영됩니다. (기존 Music 조회 시 genre는 갱신하지 않음)

## Additional Description

- `CreateRecordMusicCommand`에 `genre` 필드를 추가했습니다.
- `CreateRecordRequest.Music`에 선택 필드 `genre`를 추가하고, `toCommand`에서 `CreateRecordMusicCommand`로 전달하도록 했습니다.
- `RecordControllerV1.parseMusicList`에서 PATCH musics 요청의 각 항목에 대해 `genre`를 파싱해 command에 포함했습니다.
- `RecordService.findOrCreateMusic`에서 새 Music 생성 시 `command.genre()`를 사용하도록 수정했습니다.
- API 문서(Operation 설명, 예시, `UpdateRecordRequest` 스키마)에 musics 항목 스키마로 `genre`를 추가했습니다.