### PR TITLE
feat: 음악 검색 시 장르 반환

### DIFF
--- a/src/main/java/dalgrock/playlist/infrastructure/client/SpotifyMusicSearchClient.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/client/SpotifyMusicSearchClient.java
@@ -1,14 +1,20 @@
 package dalgrock.playlist.infrastructure.client;
 
-import dalgrock.playlist.infrastructure.spotify.dto.MusicCommand;
 import dalgrock.playlist.infrastructure.spotify.SpotifyAuthService;
+import dalgrock.playlist.infrastructure.spotify.dto.MusicCommand;
+import dalgrock.playlist.infrastructure.spotify.dto.SpotifyArtistResponse;
 import dalgrock.playlist.infrastructure.spotify.dto.SpotifySearchResponse;
 import dalgrock.playlist.infrastructure.spotify.dto.SpotifySearchResponse.ItemResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Component
@@ -17,6 +23,7 @@ public class SpotifyMusicSearchClient implements MusicSearchClient {
 
     private static final String SPOTIFY_API_HOST = "api.spotify.com";
     private static final String SEARCH_PATH = "/v1/search";
+    private static final String ARTISTS_PATH = "/v1/artists";
     private static final int SEARCH_LIMIT = 20;
 
     private final RestClient spotifyRestClient;
@@ -45,8 +52,11 @@ public class SpotifyMusicSearchClient implements MusicSearchClient {
                 return List.of();
             }
 
-            log.info("Spotify API 검색 완료: {}개 결과", response.tracks().items().size());
-            return mapToDomainModels(response.tracks().items());
+            List<ItemResponse> items = response.tracks().items();
+            log.info("Spotify API 검색 완료: {}개 결과", items.size());
+
+            Map<String, String> artistGenreMap = fetchArtistGenres(items, accessToken);
+            return mapToDomainModels(items, artistGenreMap);
         } catch (Exception e) {
             log.error("Spotify API 검색 실패", e);
             return List.of();
@@ -58,13 +68,59 @@ public class SpotifyMusicSearchClient implements MusicSearchClient {
         return "Spotify";
     }
 
-    private List<MusicCommand> mapToDomainModels(List<ItemResponse> items) {
+    private Map<String, String> fetchArtistGenres(List<ItemResponse> items, String accessToken) {
+        List<String> artistIds = items.stream()
+                .filter(item -> item.artists() != null && !item.artists().isEmpty())
+                .map(item -> item.artists().getFirst().id())
+                .filter(Objects::nonNull)
+                .distinct()
+                .toList();
+
+        if (artistIds.isEmpty()) {
+            return Map.of();
+        }
+
+        String ids = String.join(",", artistIds);
+
+        try {
+            SpotifyArtistResponse artistResponse = spotifyRestClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .scheme("https")
+                            .host(SPOTIFY_API_HOST)
+                            .path(ARTISTS_PATH)
+                            .queryParam("ids", ids)
+                            .build())
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .body(SpotifyArtistResponse.class);
+
+            if (artistResponse == null || artistResponse.artists() == null) {
+                return Map.of();
+            }
+
+            return artistResponse.artists().stream()
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toMap(
+                            SpotifyArtistResponse.ArtistDetail::id,
+                            artist -> Optional.ofNullable(artist.genres())
+                                    .filter(g -> !g.isEmpty())
+                                    .map(List::getFirst)
+                                    .orElse(null),
+                            (existing, replacement) -> existing
+                    ));
+        } catch (Exception e) {
+            log.warn("Spotify Artists API 호출 실패", e);
+            return Map.of();
+        }
+    }
+
+    private List<MusicCommand> mapToDomainModels(List<ItemResponse> items, Map<String, String> artistGenreMap) {
         return items.stream()
-                .map(this::mapToDomainModel)
+                .map(item -> mapToDomainModel(item, artistGenreMap))
                 .toList();
     }
 
-    private MusicCommand mapToDomainModel(ItemResponse item) {
+    private MusicCommand mapToDomainModel(ItemResponse item, Map<String, String> artistGenreMap) {
         String artistName = item.artists() != null && !item.artists().isEmpty()
                 ? item.artists().getFirst().name()
                 : "Unknown Artist";
@@ -79,12 +135,18 @@ public class SpotifyMusicSearchClient implements MusicSearchClient {
                 ? item.externalUrls().spotify()
                 : null;
 
+        String genre = Optional.ofNullable(item.artists())
+                .filter(a -> !a.isEmpty())
+                .map(a -> artistGenreMap.get(a.getFirst().id()))
+                .orElse(null);
+
         return new MusicCommand(
                 item.id(),
                 item.name(),
                 artistName,
                 thumbnail,
-                spotifyUrl
+                spotifyUrl,
+                genre
         );
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/spotify/MusicSearchService.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/spotify/MusicSearchService.java
@@ -4,12 +4,13 @@ import dalgrock.playlist.infrastructure.client.MusicSearchClient;
 import dalgrock.playlist.infrastructure.repository.MusicRepository;
 import dalgrock.playlist.infrastructure.spotify.dto.MusicCommand;
 import dalgrock.playlist.service.dto.response.MusicSearchResponse;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -34,7 +35,7 @@ public class MusicSearchService {
                     .toList();
         }
 
-        log.info("DB_MISS: 외부 API 호출 - 제공자={}", musicSearchClient.getProviderName());
+        log.info("DB_MISS: 외부 API 호출 - 호출={}", musicSearchClient.getProviderName());
         List<MusicCommand> externalResults = musicSearchClient.search(normalizedKeyword);
 
         log.info("{}에서 {}개 결과 반환", musicSearchClient.getProviderName(), externalResults.size());

--- a/src/main/java/dalgrock/playlist/infrastructure/spotify/dto/MusicCommand.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/spotify/dto/MusicCommand.java
@@ -7,7 +7,8 @@ public record MusicCommand(
         String title,
         String artist,
         String thumbnail,
-        String spotifyUrl
+        String spotifyUrl,
+        String genre
 ) {
 
     public static MusicCommand from(Music music) {
@@ -16,7 +17,8 @@ public record MusicCommand(
                 music.getTitle(),
                 music.getArtist(),
                 music.getThumbnail(),
-                null
+                null,
+                music.getGenre()
         );
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/spotify/dto/SpotifySearchResponse.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/spotify/dto/SpotifySearchResponse.java
@@ -29,6 +29,7 @@ public record SpotifySearchResponse(
     }
 
     public record AlbumResponse(
+            String id,
             String name,
             List<ImageResponse> images
     ) {

--- a/src/main/java/dalgrock/playlist/service/dto/response/MusicSearchResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/MusicSearchResponse.java
@@ -8,7 +8,8 @@ public record MusicSearchResponse(
         String title,
         String artist,
         String thumbnail,
-        String spotifyUrl
+        String spotifyUrl,
+        String genre
 ) {
 
     public static MusicSearchResponse from(Music music) {
@@ -17,7 +18,8 @@ public record MusicSearchResponse(
                 music.getTitle(),
                 music.getArtist(),
                 music.getThumbnail(),
-                null
+                null,
+                music.getGenre()
         );
     }
 
@@ -27,7 +29,8 @@ public record MusicSearchResponse(
                 command.title(),
                 command.artist(),
                 command.thumbnail(),
-                command.spotifyUrl()
+                command.spotifyUrl(),
+                command.genre()
         );
     }
 }


### PR DESCRIPTION
### As is

- 음악의 장르가 매핑되어 있지 않아서 분석 불가능

### To be

- 음악 검색 시 해당 곡 아티스트의 장르를 받아서 함께 저장

### Additional Description

기존 논의된 앨범 매핑의 결과가 대부분 비어있기 때문에 아티스트 매핑으로 변경하였습니다.