### PR TITLE
fix: referer이 카카오인 경우 무시하도록 분기처리 한다

### DIFF
--- a/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
@@ -60,11 +60,11 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         logger.info("origin: " + origin);
         logger.info("referer: " + referer);
 
-        if (origin != null && !origin.isBlank()) {
+        if (origin != null && !origin.isBlank() && !origin.contains("kakao.com")) {
             return buildRedirectUrl(origin);
         }
 
-        if (referer != null && !referer.isBlank()) {
+        if (referer != null && !referer.isBlank() && !referer.contains("kauth.kakao.com")) {
             try {
                 java.net.URI uri = new java.net.URI(referer);
                 String host = uri.getScheme() + "://" + uri.getAuthority();
@@ -74,7 +74,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 logger.warn("Referer 파싱 실패: " + referer, e);
             }
         }
-        logger.info("기본 redirect-uri 사용: " + targetUrl);
+
         return targetUrl;
     }
 


### PR DESCRIPTION
### As is

- 카카오 로그인 이력이 남지 않은 상태에서 로그인이 실패하는 문제 발생

### To be

- 카카오 로그인 이력이 남지 않은 상태에서 새롭게 로그인해도 카카오가 아닌 기본 referer로 처리되도록 분기