### PR TITLE
hotfix: Cookie 설정 HTTPS 방식으로 통일

### DIFF
--- a/src/main/java/dalgrock/playlist/config/OAuth2LoginOriginFilter.java
+++ b/src/main/java/dalgrock/playlist/config/OAuth2LoginOriginFilter.java
@@ -1,0 +1,51 @@
+package dalgrock.playlist.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class OAuth2LoginOriginFilter extends OncePerRequestFilter {
+
+    static final String SESSION_KEY = "OAUTH2_FRONTEND_ORIGIN";
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        if (request.getRequestURI().startsWith("/oauth2/authorization/")) {
+            String frontendOrigin = extractFrontendOrigin(request);
+            if (frontendOrigin != null) {
+                request.getSession().setAttribute(SESSION_KEY, frontendOrigin);
+                logger.info("OAuth2 시작 시 프론트엔드 origin 저장: " + frontendOrigin);
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    private String extractFrontendOrigin(HttpServletRequest request) {
+        String origin = request.getHeader("Origin");
+        if (origin != null && !origin.isBlank()) {
+            return origin;
+        }
+
+        String referer = request.getHeader("Referer");
+        if (referer != null && !referer.isBlank()) {
+            try {
+                URI uri = new URI(referer);
+                return uri.getScheme() + "://" + uri.getAuthority();
+            } catch (URISyntaxException e) {
+                logger.warn("Referer 파싱 실패: " + referer);
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
@@ -28,9 +28,6 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${app.auth.samesite-cookie}")
     private String sameSite;
 
-    @Value("${app.auth.secure-cookie}")
-    private Boolean secureHttp;
-
     private final JwtTokenProvider tokenProvider;
     private final UserRepository userRepository;
 
@@ -97,7 +94,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .path("/")
                 .httpOnly(false)
                 .maxAge(3600)
-                .secure(cookieConfig.secure());
+                .secure(true);
 
         if (cookieConfig.domain() != null) {
             cookieBuilder.domain(cookieConfig.domain());
@@ -116,37 +113,21 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     private CookieConfig extractCookieConfig(String redirectUrl) {
         try {
             java.net.URI uri = new java.net.URI(redirectUrl);
-            String scheme = uri.getScheme();
             String host = uri.getHost();
-            boolean isHttps = "https".equalsIgnoreCase(scheme);
-
-            boolean secure = isHttps;
 
             String domain = null;
             if ("localhost".equalsIgnoreCase(host)) {
                 domain = "localhost";
             }
 
-            String sameSiteValue;
-            if (!isHttps) {
-                sameSiteValue = null;
-            } else {
-                sameSiteValue = sameSite;
-            }
-            return new CookieConfig(scheme, host, domain, secure, sameSiteValue);
+            return new CookieConfig(domain, sameSite);
 
         } catch (java.net.URISyntaxException e) {
             logger.warn("redirectUrl 파싱 실패, 기본값 사용: " + redirectUrl, e);
-            return new CookieConfig("https", null, null, secureHttp, sameSite);
+            return new CookieConfig(null, sameSite);
         }
     }
 
-    private record CookieConfig(
-            String scheme,
-            String host,
-            String domain,
-            boolean secure,
-            String sameSite
-    ) {
+    private record CookieConfig(String domain, String sameSite) {
     }
 }

--- a/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
+++ b/src/main/java/dalgrock/playlist/config/OAuth2SuccessHandler.java
@@ -17,14 +17,13 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import jakarta.servlet.http.HttpSession;
+
 import java.io.IOException;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
-    @Value("${app.auth.redirect-uri}")
-    private String targetUrl;
 
     @Value("${app.auth.samesite-cookie}")
     private String sameSite;
@@ -55,27 +54,17 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     }
 
     private String determineRedirectUrl(HttpServletRequest request) {
-        String origin = request.getHeader("Origin");
-        String referer = request.getHeader("Referer");
-        logger.info("origin: " + origin);
-        logger.info("referer: " + referer);
-
-        if (origin != null && !origin.isBlank() && !origin.contains("kakao.com")) {
-            return buildRedirectUrl(origin);
-        }
-
-        if (referer != null && !referer.isBlank() && !referer.contains("kauth.kakao.com")) {
-            try {
-                java.net.URI uri = new java.net.URI(referer);
-                String host = uri.getScheme() + "://" + uri.getAuthority();
-                logger.info("Referer에서 추출한 호스트: " + host);
-                return buildRedirectUrl(host);
-            } catch (java.net.URISyntaxException e) {
-                logger.warn("Referer 파싱 실패: " + referer, e);
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            String savedOrigin = (String) session.getAttribute(OAuth2LoginOriginFilter.SESSION_KEY);
+            if (savedOrigin != null) {
+                session.removeAttribute(OAuth2LoginOriginFilter.SESSION_KEY);
+                logger.info("세션에서 프론트엔드 origin 복원: " + savedOrigin);
+                return buildRedirectUrl(savedOrigin);
             }
         }
 
-        return targetUrl;
+        throw new IllegalStateException("세션에 저장된 프론트엔드 origin이 없어 리다이렉트 URL을 결정할 수 없습니다.");
     }
 
     private String buildRedirectUrl(String baseUrl) {

--- a/src/main/java/dalgrock/playlist/config/SecurityConfig.java
+++ b/src/main/java/dalgrock/playlist/config/SecurityConfig.java
@@ -16,6 +16,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter;
 import org.springframework.security.web.authentication.HttpStatusEntryPoint;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
@@ -70,6 +71,7 @@ public class SecurityConfig {
                         .requestMatchers("/v1/**").authenticated()
                         .anyRequest().authenticated()
                 )
+                .addFilterBefore(new OAuth2LoginOriginFilter(), OAuth2AuthorizationRequestRedirectFilter.class)
                 .addFilterBefore(new JwtAuthenticationFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo.userService(customOAuth2UserService))

--- a/src/main/java/dalgrock/playlist/controller/AuthController.java
+++ b/src/main/java/dalgrock/playlist/controller/AuthController.java
@@ -30,7 +30,7 @@ public class AuthController {
                     2. 카카오 로그인 페이지로 리다이렉트 (302)
                     3. 사용자가 카카오에서 인증
                     4. 카카오가 /login/oauth2/code/kakao 로 콜백
-                    5. 인증 성공 시 /oauth-callback.html?token={jwt} 로 리다이렉트
+                    5. 인증 성공 시 {origin}/ 로 리다이렉트
                     
                     **주의:** 이 메서드는 Swagger 문서화용이며 실제로는 실행되지 않습니다.
                     """

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -57,8 +57,6 @@ app:
     server-url: "http://localhost:8080"
   auth:
     host: https://pliview.kr
-    redirect-uri: https://pliview.kr/auth/kakao/callback
-    secure-cookie: false
     samesite-cookie: None
   cors:
     allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,http://127.0.0.1:8080,https://dev.pliview.kr:5173,https://*.pliview.kr"

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -70,9 +70,7 @@ app:
     server-url: "https://api-dev.pliview.kr"
   auth:
     host: https://pliview.kr
-    redirect-uri: https://pliview.kr/auth/kakao/callback
-    secure-cookie: false
-    samesite-cookie: Lax
+    samesite-cookie: None
   cors:
     allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,https://localhost:5173,http://127.0.0.1:8080,https://dev.pliview.kr:5173"
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -63,7 +63,7 @@ management:
 
 jwt:
   secret: ${JWT_SECRET_KEY}
-  expiration: 3600000
+  expiration: 3600000000
 
 app:
   api:


### PR DESCRIPTION
## As is

- 기존 클라이언트의 http와 https 요청을 모두 상황 별로 처리했습니다.

## To be

- 클라이언트의 https 요청만 허용하도록 http 처리 분기를 제거합니다.
- 쿠키 설정을 통일합니다. (secure: true, sameSite: None)