### PR TITLE
feat: 주간 리포트를 생성한다

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/ReportControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/ReportControllerV1.java
@@ -1,0 +1,38 @@
+package dalgrock.playlist.controller;
+
+import dalgrock.playlist.model.UserPrincipal;
+import dalgrock.playlist.service.ReportService;
+import dalgrock.playlist.service.dto.response.GetReportResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Report", description = "주간 리포트 API")
+@Validated
+@SecurityRequirement(name = "cookieAuth")
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/v1/report")
+public class ReportControllerV1 {
+
+    private final ReportService reportService;
+
+    @Operation(summary = "월별 리포트 조회", description = "year, month 기준 해당 달의 주차별 리포트를 조회합니다")
+    @GetMapping
+    public GetReportResponse getMonthlyReport(
+            @AuthenticationPrincipal UserPrincipal principal,
+            @RequestParam @Min(1900) @Max(2100) int year,
+            @RequestParam @Min(1) @Max(12) int month
+    ) {
+        return reportService.getMonthlyReport(principal.userId(), year, month);
+    }
+}

--- a/src/main/java/dalgrock/playlist/controller/TestController.java
+++ b/src/main/java/dalgrock/playlist/controller/TestController.java
@@ -1,12 +1,17 @@
 package dalgrock.playlist.controller;
 
 import dalgrock.playlist.core.jwt.JwtTokenProvider;
+import dalgrock.playlist.model.Report;
+import dalgrock.playlist.service.WeeklyReportGenerationService;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -17,9 +22,29 @@ public class TestController {
     private static final String COOKIE_NAME = "access_token";
 
     private final JwtTokenProvider tokenProvider;
+    private final WeeklyReportGenerationService weeklyReportGenerationService;
 
     @Value("${jwt.expiration}")
     private long jwtExpirationMs;
+
+    /**
+     * 지정한 year, month, week에 대해 주간 리포트를 생성합니다.
+     * GET /test/weekly-report?userId=1&year=2025&month=2&week=4
+     */
+    @GetMapping("/weekly-report")
+    public ResponseEntity<Map<String, Object>> generateWeeklyReport(
+            @RequestParam Long userId,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam int week) {
+        var reportOpt = weeklyReportGenerationService.generateReport(userId, year, month, week);
+        return reportOpt
+                .map(report -> ResponseEntity.ok(Map.<String, Object>of(
+                        "success", true,
+                        "reportId", report.getId(),
+                        "content", report.getContent())))
+                .orElse(ResponseEntity.ok(Map.of("success", false, "message", "해당 주차 데이터가 없거나 API 키가 설정되지 않았습니다.")));
+    }
 
     @GetMapping("/token")
     public String generateToken(HttpServletResponse response) {

--- a/src/main/java/dalgrock/playlist/infrastructure/deepseek/DeepSeekReportClient.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/deepseek/DeepSeekReportClient.java
@@ -1,0 +1,108 @@
+package dalgrock.playlist.infrastructure.deepseek;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+/**
+ * DeepSeek API 호출 (주간 음악 분석 리포트 생성).
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DeepSeekReportClient {
+
+    private static final String MODEL = "deepseek-chat";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Value("${deepseek.api-key:}")
+    private String apiKey;
+
+    @Value("${deepseek.api-url:https://api.deepseek.com/chat/completions}")
+    private String apiUrl;
+
+    /**
+     * DeepSeek API 키가 설정되어 있는지 여부.
+     */
+    public boolean isConfigured() {
+        return apiKey != null && !apiKey.isBlank();
+    }
+
+    /**
+     * 시스템 메시지로 채팅 완료 요청을 보내고, 응답의 content 텍스트를 반환합니다.
+     *
+     * @param systemMessage 시스템 메시지 (분석 데이터 + 생성 지시 + 출력 형식)
+     * @return DeepSeek 응답 content (리포트 JSON 문자열 등)
+     * @throws DeepSeekReportException API 키 미설정, HTTP 오류, 응답 파싱 오류 시
+     */
+    public String ask(String systemMessage) {
+        if (apiKey == null || apiKey.isBlank()) {
+            throw new DeepSeekReportException("deepseek.api-key is not configured");
+        }
+
+        Map<String, Object> body = Map.of(
+                "model", MODEL,
+                "messages", List.of(Map.of("role", "system", "content", systemMessage)),
+                "stream", false
+        );
+        String bodyJson;
+        try {
+            bodyJson = OBJECT_MAPPER.writeValueAsString(body);
+        } catch (JsonProcessingException e) {
+            throw new DeepSeekReportException("요청 JSON 직렬화 실패", e);
+        }
+
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(30))
+                .build();
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(apiUrl))
+                .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + apiKey)
+                .timeout(Duration.ofSeconds(60))
+                .POST(HttpRequest.BodyPublishers.ofString(bodyJson, StandardCharsets.UTF_8))
+                .build();
+
+        HttpResponse<String> response;
+        try {
+            response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new DeepSeekReportException("DeepSeek API 요청 실패", e);
+        }
+
+        if (response.statusCode() != 200) {
+            throw new DeepSeekReportException(
+                    "DeepSeek API 오류: HTTP " + response.statusCode() + " - " + response.body());
+        }
+
+        try {
+            JsonNode root = OBJECT_MAPPER.readTree(response.body());
+            JsonNode choices = root.path("choices");
+            if (choices.isEmpty()) {
+                throw new DeepSeekReportException("DeepSeek 응답에서 내용을 찾을 수 없습니다.");
+            }
+            JsonNode messageContent = choices.get(0).path("message").path("content");
+            if (messageContent.isMissingNode() || !messageContent.isTextual()) {
+                throw new DeepSeekReportException("DeepSeek 응답에서 내용을 찾을 수 없습니다.");
+            }
+            return messageContent.asText();
+        } catch (JsonProcessingException e) {
+            throw new DeepSeekReportException("DeepSeek 응답 파싱 실패", e);
+        }
+    }
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/deepseek/DeepSeekReportException.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/deepseek/DeepSeekReportException.java
@@ -1,0 +1,15 @@
+package dalgrock.playlist.infrastructure.deepseek;
+
+/**
+ * DeepSeek API 호출 또는 응답 파싱 실패 시 사용합니다.
+ */
+public class DeepSeekReportException extends RuntimeException {
+
+    public DeepSeekReportException(String message) {
+        super(message);
+    }
+
+    public DeepSeekReportException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/ReportRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/ReportRepository.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.model.Report;
+import java.util.List;
 import java.util.Optional;
 
 public interface ReportRepository {
@@ -8,4 +9,6 @@ public interface ReportRepository {
     Report save(Report report);
 
     Optional<Report> findByUserIdAndWeeklyId(Long userId, Long weeklyId);
+
+    List<Report> findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/ReportRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/ReportRepository.java
@@ -1,4 +1,11 @@
 package dalgrock.playlist.infrastructure.repository;
 
+import dalgrock.playlist.model.Report;
+import java.util.Optional;
+
 public interface ReportRepository {
+
+    Report save(Report report);
+
+    Optional<Report> findByUserIdAndWeeklyId(Long userId, Long weeklyId);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/dto/GetRecordMusicDto.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/dto/GetRecordMusicDto.java
@@ -7,4 +7,6 @@ public interface GetRecordMusicDto {
     String getArtist();
 
     String getThumbnail();
+
+    String getGenre();
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordMusicRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordMusicRepository.java
@@ -10,9 +10,9 @@ import org.springframework.data.repository.query.Param;
 public interface JpaRecordMusicRepository extends JpaRepository<RecordMusic, Long> {
 
     @Query(value = """
-            select m.title, m.artist, m.thumbnail
+            select m.title as title, m.artist as artist, m.thumbnail as thumbnail, m.genre as genre
             from record_music rm
-            inner join musics m 
+            inner join musics m
             on rm.music_id = m.id
             where rm.record_id = :recordId
             """, nativeQuery = true)

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaReportRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaReportRepository.java
@@ -1,7 +1,10 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Report;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface JpaReportRepository extends JpaRepository<Report, Long> {
+
+    Optional<Report> findByUserIdAndWeekly_Id(Long userId, Long weeklyId);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaReportRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaReportRepository.java
@@ -1,10 +1,16 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Report;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface JpaReportRepository extends JpaRepository<Report, Long> {
 
     Optional<Report> findByUserIdAndWeekly_Id(Long userId, Long weeklyId);
+
+    @Query("SELECT r FROM reports r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds")
+    List<Report> findByUserIdAndWeeklyIdIn(@Param("userId") Long userId, @Param("weeklyIds") List<Long> weeklyIds);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/ReportRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/ReportRepositoryAdapter.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.ReportRepository;
 import dalgrock.playlist.model.Report;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -20,5 +21,10 @@ public class ReportRepositoryAdapter implements ReportRepository {
     @Override
     public Optional<Report> findByUserIdAndWeeklyId(Long userId, Long weeklyId) {
         return jpaReportRepository.findByUserIdAndWeekly_Id(userId, weeklyId);
+    }
+
+    @Override
+    public List<Report> findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds) {
+        return jpaReportRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
     }
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/ReportRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/ReportRepositoryAdapter.java
@@ -1,6 +1,8 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.ReportRepository;
+import dalgrock.playlist.model.Report;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
@@ -9,4 +11,14 @@ import org.springframework.stereotype.Repository;
 public class ReportRepositoryAdapter implements ReportRepository {
 
     private final JpaReportRepository jpaReportRepository;
+
+    @Override
+    public Report save(Report report) {
+        return jpaReportRepository.save(report);
+    }
+
+    @Override
+    public Optional<Report> findByUserIdAndWeeklyId(Long userId, Long weeklyId) {
+        return jpaReportRepository.findByUserIdAndWeekly_Id(userId, weeklyId);
+    }
 }

--- a/src/main/java/dalgrock/playlist/model/Emotion.java
+++ b/src/main/java/dalgrock/playlist/model/Emotion.java
@@ -1,9 +1,8 @@
 package dalgrock.playlist.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Emotion {
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = EmotionValueConverter.class)
     @Column(name = "value", nullable = false)
     private EmotionValue value;
 

--- a/src/main/java/dalgrock/playlist/model/EmotionValue.java
+++ b/src/main/java/dalgrock/playlist/model/EmotionValue.java
@@ -7,6 +7,7 @@ public enum EmotionValue {
 
     // 들뜬
     HAPPY(EmotionCategory.EXCITED, "행복"),
+    JOY(EmotionCategory.EXCITED, "기쁨"),
     FLUTTER(EmotionCategory.EXCITED, "설렘"),
     EXCITED(EmotionCategory.EXCITED, "신남"),
     PROUD(EmotionCategory.EXCITED, "뿌듯함"),
@@ -47,9 +48,12 @@ public enum EmotionValue {
     }
 
     public static EmotionValue fromString(String text) {
-        for (EmotionValue value : EmotionValue.values()) {
-            if (value.name().equalsIgnoreCase(text)) {
-                return value;
+        if (text == null || text.isBlank()) {
+            return UNKNOWN;
+        }
+        for (EmotionValue e : EmotionValue.values()) {
+            if (e.name().equalsIgnoreCase(text) || e.value.equals(text)) {
+                return e;
             }
         }
         return UNKNOWN;

--- a/src/main/java/dalgrock/playlist/model/EmotionValueConverter.java
+++ b/src/main/java/dalgrock/playlist/model/EmotionValueConverter.java
@@ -1,0 +1,24 @@
+package dalgrock.playlist.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * DB에 enum 이름 또는 한글 표시값이 저장된 경우 모두 올바르게 매핑합니다.
+ */
+@Converter(autoApply = false)
+public class EmotionValueConverter implements AttributeConverter<EmotionValue, String> {
+
+    @Override
+    public String convertToDatabaseColumn(EmotionValue attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public EmotionValue convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return EmotionValue.UNKNOWN;
+        }
+        return EmotionValue.fromString(dbData);
+    }
+}

--- a/src/main/java/dalgrock/playlist/model/Report.java
+++ b/src/main/java/dalgrock/playlist/model/Report.java
@@ -45,8 +45,16 @@ public class Report extends BaseTimeEntity {
     @Column(columnDefinition = "TEXT")
     private String content;
 
+    public void startProcessing() {
+        this.status = ReportStatus.PROCESSING;
+    }
+
     public void complete(String content) {
         this.status = ReportStatus.COMPLETED;
         this.content = content;
+    }
+
+    public void fail() {
+        this.status = ReportStatus.FAILED;
     }
 }

--- a/src/main/java/dalgrock/playlist/model/Report.java
+++ b/src/main/java/dalgrock/playlist/model/Report.java
@@ -41,4 +41,12 @@ public class Report extends BaseTimeEntity {
     @Column(nullable = false)
     @Builder.Default
     private ReportStatus status = ReportStatus.CREATED;
+
+    @Column(columnDefinition = "TEXT")
+    private String content;
+
+    public void complete(String content) {
+        this.status = ReportStatus.COMPLETED;
+        this.content = content;
+    }
 }

--- a/src/main/java/dalgrock/playlist/model/Situation.java
+++ b/src/main/java/dalgrock/playlist/model/Situation.java
@@ -1,9 +1,8 @@
 package dalgrock.playlist.model;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Embeddable;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -15,7 +14,7 @@ import lombok.NoArgsConstructor;
 @Embeddable
 public class Situation {
 
-    @Enumerated(EnumType.STRING)
+    @Convert(converter = SituationValueConverter.class)
     @Column(name = "value", nullable = false)
     private SituationValue value;
 

--- a/src/main/java/dalgrock/playlist/model/SituationValue.java
+++ b/src/main/java/dalgrock/playlist/model/SituationValue.java
@@ -24,7 +24,7 @@ public enum SituationValue {
     NAP(SituationCategory.LEISURE, "낮잠"),
     DATE(SituationCategory.LEISURE, "데이트"),
 
-    UNKNOWN(SituationCategory.UNKNOWN, "미상");;
+    UNKNOWN(SituationCategory.UNKNOWN, "미상");
 
     private final SituationCategory category;
     private final String value;
@@ -35,9 +35,12 @@ public enum SituationValue {
     }
 
     public static SituationValue fromString(String text) {
-        for (SituationValue value : SituationValue.values()) {
-            if (value.name().equalsIgnoreCase(text)) {
-                return value;
+        if (text == null || text.isBlank()) {
+            return UNKNOWN;
+        }
+        for (SituationValue s : SituationValue.values()) {
+            if (s.name().equalsIgnoreCase(text) || s.value.equals(text)) {
+                return s;
             }
         }
         return UNKNOWN;

--- a/src/main/java/dalgrock/playlist/model/SituationValueConverter.java
+++ b/src/main/java/dalgrock/playlist/model/SituationValueConverter.java
@@ -1,0 +1,24 @@
+package dalgrock.playlist.model;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+/**
+ * DB에 enum 이름 또는 한글 표시값이 저장된 경우 모두 올바르게 매핑합니다.
+ */
+@Converter(autoApply = false)
+public class SituationValueConverter implements AttributeConverter<SituationValue, String> {
+
+    @Override
+    public String convertToDatabaseColumn(SituationValue attribute) {
+        return attribute == null ? null : attribute.name();
+    }
+
+    @Override
+    public SituationValue convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return SituationValue.UNKNOWN;
+        }
+        return SituationValue.fromString(dbData);
+    }
+}

--- a/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
+++ b/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
@@ -3,13 +3,17 @@ package dalgrock.playlist.scheduler;
 import dalgrock.playlist.infrastructure.deepseek.DeepSeekReportClient;
 import dalgrock.playlist.infrastructure.repository.UserRepository;
 import dalgrock.playlist.model.User;
-import dalgrock.playlist.service.WeeklyReportDataService;
+import dalgrock.playlist.service.WeeklyReportGenerationService;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
 
 /**
  * 주간 리포트 자동 생성 스케줄러
@@ -20,68 +24,10 @@ import java.util.List;
 @Component
 public class WeeklyReportScheduler {
 
-    private static final String DATA_FOR_CREATE_REPORT = 
-    """
-              ## 생성해야 할 항목
-              ### 1. overallSummary.title (주간 요약 타이틀)
-              
-              - 이번 주를 한 문장으로 요약 (최대 36자, 공백 포함)
-              - 주요 감정과 음악 장르를 포함
-              - 따뜻하고 공감적인 톤
-              - 이모지 사용 가능 (선택사항)
-              - 예시: "잔잔하고 외로웠던 이번 주, R&B와 함께했어요 ✨"
-              
-              ### 2. overallSummary.summaryTags (요약 태그)
-              
-              - 정확히 2개의 태그 생성
-              - 각 태그는 1~2단어
-              - 감정 상태나 음악 청취 패턴을 나타냄
-              - 예시: ["위로", "전환"]
-              
-              ### 3. weeklyEmotionSummary.title (이번 주 감정 요약)
-              
-              - 일별 감정 변화를 한 문장으로 요약
-              - 격려적이고 공감적인 톤
-              - 감정 회복이나 변화 과정을 강조
-              - 예시: "우울한 감정을 열심히 회복시켰어요"
-              
-              ### 4. emotionGenreDescriptions (감정-장르 분석 설명)
-              
-              - 각 감정-장르 조합에 대한 맞춤형 메시지
-              - "당신은 ~였어요" 형식
-              - 긍정적이고 격려적인 톤
-              - 해당 감정을 그 장르의 음악으로 해소한 사용자의 행동을 긍정적으로 해석
-              - 예시: "복잡미묘한 감정을 힙한 음악으로 해소한 당신은 분위기를 순식간에 바꾸는 반전 메이커였어요!"
-              
-              
-              ### 5. weeklyComparison.summary (지난 주와의 비교 요약)
-              
-              - 지난 주 대비 변화를 한 문장으로 요약
-              - 감정과 장르를 모두 포함
-              - 중립적이면서도 관찰적인 톤
-              - 예시: "지난 주에 비해 우울감을 더 많이 느끼고 팝 장르 음악을 많이 들은 한 주였어요"
-              
-              ### 6. weeklyComparison.nextWeekSuggestion (다음 주 제안)
-              
-              - 이번 주 분석을 바탕으로 다음 주 음악 감상 제안
-              - "~하는 건 어떨까요?" 형식 권장
-              - 격려적이고 제안하는 톤
-              - 구체적이면서도 부드러운 표현
-              - 예시: "다음 주에는 신나는 음악으로 기분을 전환해 보는 건 어떨까요?"
-              """;
-
-    private static final String OUTPUT_FORMAT = """
-              ## 출력 형식
-              
-              다음 JSON 형식으로 응답해주세요:
-              - overallSummary: { title, summaryTags }
-              - weeklyEmotionSummary: { title }
-              - emotionGenreDescriptions: [ { emotion, description }, ... ]
-              - weeklyComparison: { summary, nextWeekSuggestion }
-              """;
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
 
     private final UserRepository userRepository;
-    private final WeeklyReportDataService weeklyReportDataService;
+    private final WeeklyReportGenerationService weeklyReportGenerationService;
     private final DeepSeekReportClient deepSeekReportClient;
 
     @Scheduled(cron = "0 0 18 * * SUN", zone = "Asia/Seoul")
@@ -94,15 +40,19 @@ public class WeeklyReportScheduler {
             List<User> users = userRepository.findAll();
             log.info("이번주 분석 유저수: {}", users.size());
 
+            LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
+            int year = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getYear();
+            int month = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getMonthValue();
+            int week = (today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getDayOfMonth() - 1) / 7 + 1;
+
             int successCount = 0;
             int failureCount = 0;
 
             for (User user : users) {
                 try {
-                    String reportContent = processUserReport(user);
-                    if (reportContent != null) {
+                    if (weeklyReportGenerationService.generateReport(user.getId(), year, month, week).isPresent()) {
                         successCount++;
-                        log.debug("주간 리포트 생성 완료, 사용자ID: {}, 응답 길이: {}", user.getId(), reportContent.length());
+                        log.debug("주간 리포트 생성 완료, 사용자ID: {}", user.getId());
                     }
                 } catch (Exception e) {
                     failureCount++;
@@ -112,27 +62,6 @@ public class WeeklyReportScheduler {
 
         } catch (Exception e) {
             log.error("Fatal error during weekly report generation", e);
-        }
-    }
-
-    /**
-     * 한 사용자에 대해 주간 분석 데이터로 DeepSeek를 호출하고, 리포트 문자열을 반환합니다.
-     * (제공해주신 DeepSeek 코드와 동일한 결과를 반환합니다.)
-     */
-    private String processUserReport(User user) {
-        try {
-            String dataForAnalysis = weeklyReportDataService.buildDataForAnalysis(user.getId());
-            String systemMessage = "당신은 음악 기록 서비스의 주간 분석 리포트를 생성하는 AI 어시스턴트입니다.\n"
-                    + "사용자의 이번 주 음악 기록 데이터를 분석하여 따뜻하고 공감적인 문장들을 생성해주세요.\n"
-                    + dataForAnalysis + "\n"
-                    + DATA_FOR_CREATE_REPORT + "\n"
-                    + OUTPUT_FORMAT;
-
-            String reportContent = deepSeekReportClient.ask(systemMessage);
-            return reportContent;
-        } catch (Exception e) {
-            log.error("분석 실패, 사용자ID: {}", user.getId(), e);
-            throw e;
         }
     }
 }

--- a/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
+++ b/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
@@ -1,7 +1,9 @@
 package dalgrock.playlist.scheduler;
 
+import dalgrock.playlist.infrastructure.deepseek.DeepSeekReportClient;
 import dalgrock.playlist.infrastructure.repository.UserRepository;
 import dalgrock.playlist.model.User;
+import dalgrock.playlist.service.WeeklyReportDataService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -18,10 +20,76 @@ import java.util.List;
 @Component
 public class WeeklyReportScheduler {
 
+    private static final String DATA_FOR_CREATE_REPORT = 
+    """
+              ## 생성해야 할 항목
+              ### 1. overallSummary.title (주간 요약 타이틀)
+              
+              - 이번 주를 한 문장으로 요약 (최대 36자, 공백 포함)
+              - 주요 감정과 음악 장르를 포함
+              - 따뜻하고 공감적인 톤
+              - 이모지 사용 가능 (선택사항)
+              - 예시: "잔잔하고 외로웠던 이번 주, R&B와 함께했어요 ✨"
+              
+              ### 2. overallSummary.summaryTags (요약 태그)
+              
+              - 정확히 2개의 태그 생성
+              - 각 태그는 1~2단어
+              - 감정 상태나 음악 청취 패턴을 나타냄
+              - 예시: ["위로", "전환"]
+              
+              ### 3. weeklyEmotionSummary.title (이번 주 감정 요약)
+              
+              - 일별 감정 변화를 한 문장으로 요약
+              - 격려적이고 공감적인 톤
+              - 감정 회복이나 변화 과정을 강조
+              - 예시: "우울한 감정을 열심히 회복시켰어요"
+              
+              ### 4. emotionGenreDescriptions (감정-장르 분석 설명)
+              
+              - 각 감정-장르 조합에 대한 맞춤형 메시지
+              - "당신은 ~였어요" 형식
+              - 긍정적이고 격려적인 톤
+              - 해당 감정을 그 장르의 음악으로 해소한 사용자의 행동을 긍정적으로 해석
+              - 예시: "복잡미묘한 감정을 힙한 음악으로 해소한 당신은 분위기를 순식간에 바꾸는 반전 메이커였어요!"
+              
+              
+              ### 5. weeklyComparison.summary (지난 주와의 비교 요약)
+              
+              - 지난 주 대비 변화를 한 문장으로 요약
+              - 감정과 장르를 모두 포함
+              - 중립적이면서도 관찰적인 톤
+              - 예시: "지난 주에 비해 우울감을 더 많이 느끼고 팝 장르 음악을 많이 들은 한 주였어요"
+              
+              ### 6. weeklyComparison.nextWeekSuggestion (다음 주 제안)
+              
+              - 이번 주 분석을 바탕으로 다음 주 음악 감상 제안
+              - "~하는 건 어떨까요?" 형식 권장
+              - 격려적이고 제안하는 톤
+              - 구체적이면서도 부드러운 표현
+              - 예시: "다음 주에는 신나는 음악으로 기분을 전환해 보는 건 어떨까요?"
+              """;
+
+    private static final String OUTPUT_FORMAT = """
+              ## 출력 형식
+              
+              다음 JSON 형식으로 응답해주세요:
+              - overallSummary: { title, summaryTags }
+              - weeklyEmotionSummary: { title }
+              - emotionGenreDescriptions: [ { emotion, description }, ... ]
+              - weeklyComparison: { summary, nextWeekSuggestion }
+              """;
+
     private final UserRepository userRepository;
+    private final WeeklyReportDataService weeklyReportDataService;
+    private final DeepSeekReportClient deepSeekReportClient;
 
     @Scheduled(cron = "0 0 18 * * SUN", zone = "Asia/Seoul")
     public void generateWeeklyReports() {
+        if (!deepSeekReportClient.isConfigured()) {
+            log.warn("주간 리포트 스킵: deepseek.api-key가 설정되지 않았습니다.");
+            return;
+        }
         try {
             List<User> users = userRepository.findAll();
             log.info("이번주 분석 유저수: {}", users.size());
@@ -31,8 +99,11 @@ public class WeeklyReportScheduler {
 
             for (User user : users) {
                 try {
-                    processUserReport(user);
-                    successCount++;
+                    String reportContent = processUserReport(user);
+                    if (reportContent != null) {
+                        successCount++;
+                        log.debug("주간 리포트 생성 완료, 사용자ID: {}, 응답 길이: {}", user.getId(), reportContent.length());
+                    }
                 } catch (Exception e) {
                     failureCount++;
                 }
@@ -44,9 +115,21 @@ public class WeeklyReportScheduler {
         }
     }
 
-    private void processUserReport(User user) {
+    /**
+     * 한 사용자에 대해 주간 분석 데이터로 DeepSeek를 호출하고, 리포트 문자열을 반환합니다.
+     * (제공해주신 DeepSeek 코드와 동일한 결과를 반환합니다.)
+     */
+    private String processUserReport(User user) {
         try {
-            // todo: 주간 분석 작업
+            String dataForAnalysis = weeklyReportDataService.buildDataForAnalysis(user.getId());
+            String systemMessage = "당신은 음악 기록 서비스의 주간 분석 리포트를 생성하는 AI 어시스턴트입니다.\n"
+                    + "사용자의 이번 주 음악 기록 데이터를 분석하여 따뜻하고 공감적인 문장들을 생성해주세요.\n"
+                    + dataForAnalysis + "\n"
+                    + DATA_FOR_CREATE_REPORT + "\n"
+                    + OUTPUT_FORMAT;
+
+            String reportContent = deepSeekReportClient.ask(systemMessage);
+            return reportContent;
         } catch (Exception e) {
             log.error("분석 실패, 사용자ID: {}", user.getId(), e);
             throw e;

--- a/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
+++ b/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
@@ -62,7 +62,7 @@ public class WeeklyReportScheduler {
             log.info("주간 레코드 생성. 성공: {}, 실패: {}", successCount, failureCount);
 
         } catch (Exception e) {
-            log.error("Fatal error during weekly report generation", e);
+            log.error("주간 리포트 생성 중 치명적 오류 발생", e);
         }
     }
 }

--- a/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
+++ b/src/main/java/dalgrock/playlist/scheduler/WeeklyReportScheduler.java
@@ -56,6 +56,7 @@ public class WeeklyReportScheduler {
                     }
                 } catch (Exception e) {
                     failureCount++;
+                    log.error("주간 리포트 생성 실패, 사용자ID: {}", user.getId(), e);
                 }
             }
             log.info("주간 레코드 생성. 성공: {}, 실패: {}", successCount, failureCount);

--- a/src/main/java/dalgrock/playlist/service/ReportService.java
+++ b/src/main/java/dalgrock/playlist/service/ReportService.java
@@ -1,0 +1,151 @@
+package dalgrock.playlist.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import dalgrock.playlist.infrastructure.repository.RecordRepository;
+import dalgrock.playlist.infrastructure.repository.ReportRepository;
+import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
+import dalgrock.playlist.model.Record;
+import dalgrock.playlist.model.Report;
+import dalgrock.playlist.model.ReportStatus;
+import dalgrock.playlist.model.Weekly;
+import dalgrock.playlist.service.dto.response.GetReportResponse;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class ReportService {
+
+    private final WeeklyRepository weeklyRepository;
+    private final RecordRepository recordRepository;
+    private final ReportRepository reportRepository;
+    private final ObjectMapper objectMapper;
+
+    public GetReportResponse getMonthlyReport(Long userId, int year, int month) {
+        List<Weekly> weeklies = weeklyRepository.findByYearAndMonth(year, month);
+        if (weeklies.isEmpty()) {
+            return new GetReportResponse(year, month, List.of());
+        }
+
+        List<Long> weeklyIds = weeklies.stream().map(Weekly::getId).toList();
+
+        List<Record> allRecords = recordRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
+        Map<Long, List<Record>> recordsByWeeklyId = allRecords.stream()
+                .collect(Collectors.groupingBy(r -> r.getWeekly().getId()));
+
+        List<Report> allReports = reportRepository.findByUserIdAndWeeklyIdIn(userId, weeklyIds);
+        Map<Long, Report> reportByWeeklyId = allReports.stream()
+                .collect(Collectors.toMap(r -> r.getWeekly().getId(), r -> r, (a, b) -> a));
+
+        List<GetReportResponse.WeeklyReportItem> items = weeklies.stream()
+                .sorted(Comparator.comparingInt(Weekly::getWeek))
+                .map(weekly -> buildWeeklyItem(
+                        weekly,
+                        recordsByWeeklyId.getOrDefault(weekly.getId(), List.of()),
+                        reportByWeeklyId.get(weekly.getId())
+                ))
+                .toList();
+
+        return new GetReportResponse(year, month, items);
+    }
+
+    private GetReportResponse.WeeklyReportItem buildWeeklyItem(
+            Weekly weekly, List<Record> records, Report report) {
+
+        int recordCount = records.size();
+
+        List<String> allThumbnails = records.stream()
+                .map(Record::getThumbnail)
+                .filter(t -> t != null && !t.isBlank())
+                .distinct()
+                .limit(5)
+                .toList();
+
+        String representativeThumbnail = allThumbnails.isEmpty() ? null : allThumbnails.get(0);
+        List<String> thumbnails = buildPaddedThumbnails(allThumbnails, representativeThumbnail);
+
+        if (report != null && report.getStatus() == ReportStatus.COMPLETED) {
+            String title = extractTitle(report.getContent());
+            List<String> emotions = extractSummaryTags(report.getContent());
+            return new GetReportResponse.WeeklyReportItem(
+                    weekly.getWeek(), report.getId(), "COMPLETED",
+                    title, recordCount, emotions,
+                    representativeThumbnail, thumbnails
+            );
+        }
+
+        List<String> emotions = extractEmotionsFromRecords(records);
+        Long reportId = report != null ? report.getId() : null;
+        return new GetReportResponse.WeeklyReportItem(
+                weekly.getWeek(), reportId, "ANALYZING",
+                null, recordCount, emotions,
+                representativeThumbnail, thumbnails
+        );
+    }
+
+    /**
+     * representativeThumbnail 1개 + 나머지 썸네일로 thumbnails 배열 4개를 구성.
+     * 부족 시 representativeThumbnail로 패딩.
+     */
+    private List<String> buildPaddedThumbnails(List<String> allThumbnails, String representativeThumbnail) {
+        if (representativeThumbnail == null) {
+            return new ArrayList<>();
+        }
+        List<String> result = allThumbnails.size() > 1
+                ? new ArrayList<>(allThumbnails.subList(1, allThumbnails.size()))
+                : new ArrayList<>();
+        while (result.size() < 4) {
+            result.add(representativeThumbnail);
+        }
+        return result;
+    }
+
+    private List<String> extractEmotionsFromRecords(List<Record> records) {
+        return records.stream()
+                .flatMap(r -> r.getEmotions().stream())
+                .map(e -> e.getDisplayValue())
+                .distinct()
+                .toList();
+    }
+
+    private String extractTitle(String content) {
+        if (content == null || content.isBlank()) {
+            return null;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(content);
+            JsonNode titleNode = root.path("overallSummary").path("title");
+            return titleNode.isMissingNode() ? null : titleNode.asText(null);
+        } catch (Exception e) {
+            log.warn("Failed to parse report content for title", e);
+            return null;
+        }
+    }
+
+    private List<String> extractSummaryTags(String content) {
+        if (content == null || content.isBlank()) {
+            return List.of();
+        }
+        try {
+            JsonNode root = objectMapper.readTree(content);
+            JsonNode tagsNode = root.path("overallSummary").path("summaryTags");
+            if (tagsNode.isMissingNode() || !tagsNode.isArray()) {
+                return List.of();
+            }
+            List<String> tags = new ArrayList<>();
+            tagsNode.forEach(n -> tags.add(n.asText()));
+            return tags;
+        } catch (Exception e) {
+            log.warn("Failed to parse report content for summaryTags", e);
+            return List.of();
+        }
+    }
+}

--- a/src/main/java/dalgrock/playlist/service/ReportService.java
+++ b/src/main/java/dalgrock/playlist/service/ReportService.java
@@ -46,7 +46,7 @@ public class ReportService {
                 .collect(Collectors.toMap(r -> r.getWeekly().getId(), r -> r, (a, b) -> a));
 
         List<GetReportResponse.WeeklyReportItem> items = weeklies.stream()
-                .sorted(Comparator.comparingInt(Weekly::getWeek))
+                .sorted(Comparator.comparingInt(Weekly::getWeek).reversed())
                 .map(weekly -> buildWeeklyItem(
                         weekly,
                         recordsByWeeklyId.getOrDefault(weekly.getId(), List.of()),

--- a/src/main/java/dalgrock/playlist/service/ReportService.java
+++ b/src/main/java/dalgrock/playlist/service/ReportService.java
@@ -125,7 +125,7 @@ public class ReportService {
             JsonNode titleNode = root.path("overallSummary").path("title");
             return titleNode.isMissingNode() ? null : titleNode.asText(null);
         } catch (Exception e) {
-            log.warn("Failed to parse report content for title", e);
+            log.warn("리포트 content에서 title 파싱 실패", e);
             return null;
         }
     }
@@ -144,7 +144,7 @@ public class ReportService {
             tagsNode.forEach(n -> tags.add(n.asText()));
             return tags;
         } catch (Exception e) {
-            log.warn("Failed to parse report content for summaryTags", e);
+            log.warn("리포트 content에서 summaryTags 파싱 실패", e);
             return List.of();
         }
     }

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
@@ -1,0 +1,154 @@
+package dalgrock.playlist.service;
+
+import dalgrock.playlist.infrastructure.repository.RecordMusicRepository;
+import dalgrock.playlist.infrastructure.repository.RecordRepository;
+import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
+import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
+import dalgrock.playlist.model.Record;
+import dalgrock.playlist.model.Weekly;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 주간 리포트용 분석 데이터 문자열을 생성합니다.
+ * DeepSeek 프롬프트의 "이번 주 기록 데이터" 블록과 동일한 형식으로 맞춥니다.
+ */
+@RequiredArgsConstructor
+@Service
+public class WeeklyReportDataService {
+
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
+
+    private final WeeklyRepository weeklyRepository;
+    private final RecordRepository recordRepository;
+    private final RecordMusicRepository recordMusicRepository;
+
+    /**
+     * 해당 사용자의 "이번 주" (오늘 기준 월~일 주) 기록으로 분석 데이터 문자열을 만듭니다.
+     */
+    @Transactional(readOnly = true)
+    public String buildDataForAnalysis(Long userId) {
+        LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
+        int year = getYearOfWeek(today);
+        int month = getMonthOfWeek(today);
+        int week = getWeekOfMonth(today);
+
+        Optional<Weekly> weeklyOpt = weeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+
+        List<Record> records = recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(weeklyOpt.get().getId()));
+        return buildDataForAnalysisFromRecords(records);
+    }
+
+    private static int getYearOfWeek(LocalDate date) {
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getYear();
+    }
+
+    private static int getMonthOfWeek(LocalDate date) {
+        return date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY)).getMonthValue();
+    }
+
+    private static int getWeekOfMonth(LocalDate date) {
+        LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        return (monday.getDayOfMonth() - 1) / 7 + 1;
+    }
+
+    private String buildDataForAnalysisFromRecords(List<Record> records) {
+        int totalRecords = records.size();
+        List<String> allEmotions = new ArrayList<>();
+        List<String> allGenres = new ArrayList<>();
+        List<List<String>> dailyEmotions = new ArrayList<>();
+        Map<String, List<Map<String, Object>>> emotionGenreCombinations = new LinkedHashMap<>();
+        Map<String, List<Map<String, String>>> situationMusics = new LinkedHashMap<>();
+        int totalMusicCount = 0;
+
+        for (Record record : records) {
+            List<String> emotions = record.getEmotionsToString();
+            allEmotions.addAll(emotions);
+            dailyEmotions.add(emotions.isEmpty() ? List.of() : emotions);
+
+            List<String> situations = record.getSituationsToString();
+            List<GetRecordMusicDto> musics = recordMusicRepository.findAllByRecordId(record.getId());
+            totalMusicCount += musics.size();
+
+            for (GetRecordMusicDto m : musics) {
+                String genre = (m.getGenre() != null && !m.getGenre().isBlank()) ? m.getGenre() : "미분류";
+                allGenres.add(genre);
+                for (String em : emotions) {
+                    emotionGenreCombinations
+                            .computeIfAbsent(em, k -> new ArrayList<>())
+                            .add(Map.<String, Object>of(genre, 1));
+                }
+                for (String sit : situations) {
+                    situationMusics
+                            .computeIfAbsent(sit, k -> new ArrayList<>())
+                            .add(Map.of("title", m.getTitle() != null ? m.getTitle() : "", "genre", genre));
+                }
+            }
+        }
+
+        long uniqueMusicCount = records.stream()
+                .flatMap(r -> recordMusicRepository.findAllByRecordId(r.getId()).stream())
+                .map(m -> m.getTitle() + "|" + m.getArtist())
+                .distinct()
+                .count();
+
+        Map<String, Long> emotionCounts = allEmotions.stream()
+                .collect(Collectors.groupingBy(e -> e, Collectors.counting()));
+        Map<String, Long> genreCounts = allGenres.stream()
+                .collect(Collectors.groupingBy(g -> g, Collectors.counting()));
+
+        List<String> topEmotions = emotionCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(3)
+                .map(Map.Entry::getKey)
+                .toList();
+        List<String> topGenres = genreCounts.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(3)
+                .map(Map.Entry::getKey)
+                .toList();
+
+        // 감정별 장르 조합 단순화: 감정 -> [ { "장르": count }, ... ]
+        Map<String, Map<String, Long>> emotionGenreAggregated = new LinkedHashMap<>();
+        for (Map.Entry<String, List<Map<String, Object>>> e : emotionGenreCombinations.entrySet()) {
+            Map<String, Long> genreCount = new LinkedHashMap<>();
+            for (Map<String, Object> pair : e.getValue()) {
+                for (Map.Entry<String, Object> entry : pair.entrySet()) {
+                    String g = entry.getKey();
+                    genreCount.merge(g, 1L, Long::sum);
+                }
+            }
+            emotionGenreAggregated.put(e.getKey(), genreCount);
+        }
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("  ## 이번 주 기록 데이터 (사용자 데이터)\n");
+        sb.append("  ### 전체 통계\n");
+        sb.append("  {\"총 기록 수\": ").append(totalRecords)
+                .append(", \"총 음악 수\": ").append(totalMusicCount)
+                .append(", \"고유 음악 수\": ").append(uniqueMusicCount).append("}\n\n");
+        sb.append("  ### 감정 분포\n  ").append(emotionCounts.toString()).append("\n\n");
+        sb.append("  ### 음악 장르 분포\n  ").append(genreCounts.toString()).append("\n\n");
+        sb.append("  ### 주요 감정 (상위 3개)\n  ").append(topEmotions).append("\n\n");
+        sb.append("  ### 주요 장르 (상위 3개)\n  ").append(topGenres).append("\n\n");
+        sb.append("  ### 일별 감정 변화 (string[][])\n\n  ").append(dailyEmotions).append("\n\n");
+        sb.append("  ### 감정별 음악 장르 조합\n  ").append(emotionGenreAggregated).append("\n\n");
+        sb.append("  ### 상황별 음악 청취\n  ").append(situationMusics).append("\n\n");
+        sb.append("  ### 지난 주와의 비교\n\n  ### 감정 변화\n  {\"증가한 감정\": [], \"감소한 감정\": []}\n\n");
+        sb.append("  ### 장르 변화\n  {\"증가한 장르\": [], \"감소한 장르\": []}\n\n");
+        sb.append("  ### 지난 주 통계\n  {\"감정 분포\": {}, \"장르 분포\": {}}\n");
+        return sb.toString();
+    }
+}

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
@@ -4,6 +4,7 @@ import dalgrock.playlist.infrastructure.repository.RecordMusicRepository;
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
 import dalgrock.playlist.infrastructure.repository.WeeklyRepository;
 import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
+import dalgrock.playlist.model.Emotion;
 import dalgrock.playlist.model.Record;
 import dalgrock.playlist.model.Weekly;
 import java.time.DayOfWeek;
@@ -64,19 +65,31 @@ public class WeeklyReportDataService {
         return (monday.getDayOfMonth() - 1) / 7 + 1;
     }
 
+    private static Map<String, String> toEmotionWithCategory(Emotion emotion) {
+        String category = emotion.getValue().getCategory().getValue();
+        String emotionValue = emotion.getDisplayValue();
+        return Map.of("category", category, "emotion", emotionValue);
+    }
+
+    private static String emotionKey(Map<String, String> em) {
+        return em.get("category") + "|" + em.get("emotion");
+    }
+
     private String buildDataForAnalysisFromRecords(List<Record> records) {
         int totalRecords = records.size();
-        List<String> allEmotions = new ArrayList<>();
+        List<Map<String, String>> allEmotions = new ArrayList<>();
         List<String> allGenres = new ArrayList<>();
-        List<List<String>> dailyEmotions = new ArrayList<>();
+        List<List<Map<String, String>>> dailyEmotions = new ArrayList<>();
         Map<String, List<Map<String, Object>>> emotionGenreCombinations = new LinkedHashMap<>();
         Map<String, List<Map<String, String>>> situationMusics = new LinkedHashMap<>();
         int totalMusicCount = 0;
 
         for (Record record : records) {
-            List<String> emotions = record.getEmotionsToString();
-            allEmotions.addAll(emotions);
-            dailyEmotions.add(emotions.isEmpty() ? List.of() : emotions);
+            List<Map<String, String>> emotionsWithCategory = record.getEmotions().stream()
+                    .map(WeeklyReportDataService::toEmotionWithCategory)
+                    .toList();
+            allEmotions.addAll(emotionsWithCategory);
+            dailyEmotions.add(emotionsWithCategory.isEmpty() ? List.of() : emotionsWithCategory);
 
             List<String> situations = record.getSituationsToString();
             List<GetRecordMusicDto> musics = recordMusicRepository.findAllByRecordId(record.getId());
@@ -85,9 +98,10 @@ public class WeeklyReportDataService {
             for (GetRecordMusicDto m : musics) {
                 String genre = (m.getGenre() != null && !m.getGenre().isBlank()) ? m.getGenre() : "미분류";
                 allGenres.add(genre);
-                for (String em : emotions) {
+                for (Map<String, String> em : emotionsWithCategory) {
+                    String key = emotionKey(em);
                     emotionGenreCombinations
-                            .computeIfAbsent(em, k -> new ArrayList<>())
+                            .computeIfAbsent(key, k -> new ArrayList<>())
                             .add(Map.<String, Object>of(genre, 1));
                 }
                 for (String sit : situations) {
@@ -105,14 +119,17 @@ public class WeeklyReportDataService {
                 .count();
 
         Map<String, Long> emotionCounts = allEmotions.stream()
-                .collect(Collectors.groupingBy(e -> e, Collectors.counting()));
+                .collect(Collectors.groupingBy(WeeklyReportDataService::emotionKey, Collectors.counting()));
         Map<String, Long> genreCounts = allGenres.stream()
                 .collect(Collectors.groupingBy(g -> g, Collectors.counting()));
 
-        List<String> topEmotions = emotionCounts.entrySet().stream()
+        List<Map<String, String>> topEmotions = emotionCounts.entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
                 .limit(3)
-                .map(Map.Entry::getKey)
+                .map(e -> {
+                    String[] parts = e.getKey().split("\\|", 2);
+                    return Map.<String, String>of("category", parts[0], "emotion", parts[1]);
+                })
                 .toList();
         List<String> topGenres = genreCounts.entrySet().stream()
                 .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
@@ -120,7 +137,7 @@ public class WeeklyReportDataService {
                 .map(Map.Entry::getKey)
                 .toList();
 
-        // 감정별 장르 조합 단순화: 감정 -> [ { "장르": count }, ... ]
+        // 감정별 장르 조합 단순화: {category, emotion} -> [ { "장르": count }, ... ]
         Map<String, Map<String, Long>> emotionGenreAggregated = new LinkedHashMap<>();
         for (Map.Entry<String, List<Map<String, Object>>> e : emotionGenreCombinations.entrySet()) {
             Map<String, Long> genreCount = new LinkedHashMap<>();
@@ -133,18 +150,39 @@ public class WeeklyReportDataService {
             emotionGenreAggregated.put(e.getKey(), genreCount);
         }
 
+        List<Map<String, Object>> emotionCountsFormatted = emotionCounts.entrySet().stream()
+                .map(e -> {
+                    String[] parts = e.getKey().split("\\|", 2);
+                    return Map.<String, Object>of(
+                            "category", parts[0],
+                            "emotion", parts[1],
+                            "count", e.getValue()
+                    );
+                })
+                .toList();
+
         StringBuilder sb = new StringBuilder();
         sb.append("  ## 이번 주 기록 데이터 (사용자 데이터)\n");
         sb.append("  ### 전체 통계\n");
         sb.append("  {\"총 기록 수\": ").append(totalRecords)
                 .append(", \"총 음악 수\": ").append(totalMusicCount)
                 .append(", \"고유 음악 수\": ").append(uniqueMusicCount).append("}\n\n");
-        sb.append("  ### 감정 분포\n  ").append(emotionCounts.toString()).append("\n\n");
+        sb.append("  ### 감정 분포 (category, emotion, count)\n  ").append(emotionCountsFormatted).append("\n\n");
         sb.append("  ### 음악 장르 분포\n  ").append(genreCounts.toString()).append("\n\n");
-        sb.append("  ### 주요 감정 (상위 3개)\n  ").append(topEmotions).append("\n\n");
+        sb.append("  ### 주요 감정 (상위 3개, {category, emotion})\n  ").append(topEmotions).append("\n\n");
         sb.append("  ### 주요 장르 (상위 3개)\n  ").append(topGenres).append("\n\n");
-        sb.append("  ### 일별 감정 변화 (string[][])\n\n  ").append(dailyEmotions).append("\n\n");
-        sb.append("  ### 감정별 음악 장르 조합\n  ").append(emotionGenreAggregated).append("\n\n");
+        sb.append("  ### 일별 감정 변화 ({category, emotion}[][])\n\n  ").append(dailyEmotions).append("\n\n");
+        List<Map<String, Object>> emotionGenreFormatted = emotionGenreAggregated.entrySet().stream()
+                .map(e -> {
+                    String[] parts = e.getKey().split("\\|", 2);
+                    return Map.<String, Object>of(
+                            "category", parts[0],
+                            "emotion", parts[1],
+                            "genres", e.getValue()
+                    );
+                })
+                .toList();
+        sb.append("  ### 감정별 음악 장르 조합 ({category, emotion, genres})\n  ").append(emotionGenreFormatted).append("\n\n");
         sb.append("  ### 상황별 음악 청취\n  ").append(situationMusics).append("\n\n");
         sb.append("  ### 지난 주와의 비교\n\n  ### 감정 변화\n  {\"증가한 감정\": [], \"감소한 감정\": []}\n\n");
         sb.append("  ### 장르 변화\n  {\"증가한 장르\": [], \"감소한 장르\": []}\n\n");

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportDataService.java
@@ -7,6 +7,7 @@ import dalgrock.playlist.infrastructure.repository.dto.GetRecordMusicDto;
 import dalgrock.playlist.model.Emotion;
 import dalgrock.playlist.model.Record;
 import dalgrock.playlist.model.Weekly;
+import dalgrock.playlist.service.dto.WeeklyReportPayloadData;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -17,6 +18,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -37,6 +40,39 @@ public class WeeklyReportDataService {
     private final RecordMusicRepository recordMusicRepository;
 
     /**
+     * 해당 사용자의 "이번 주" (오늘 기준 월~일 주) 리포트 병합용 페이로드 데이터를 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    public Optional<WeeklyReportPayloadData> getReportPayloadData(Long userId) {
+        LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
+        int year = getYearOfWeek(today);
+        int month = getMonthOfWeek(today);
+        int week = getWeekOfMonth(today);
+        return getReportPayloadData(userId, year, month, week);
+    }
+
+    /**
+     * 지정한 year, month, week에 해당하는 주간 리포트 병합용 페이로드 데이터를 반환합니다.
+     */
+    @Transactional(readOnly = true)
+    public Optional<WeeklyReportPayloadData> getReportPayloadData(Long userId, int year, int month, int week) {
+        Optional<Weekly> weeklyOpt = weeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+        if (weeklyOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        Weekly weekly = weeklyOpt.get();
+        List<Record> records = recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(weekly.getId()));
+
+        int[] prev = getPreviousWeek(year, month, week);
+        List<Record> prevRecords = weeklyRepository.findByYearAndMonthAndWeek(prev[0], prev[1], prev[2])
+                .map(w -> recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(w.getId())))
+                .orElse(List.of());
+
+        return Optional.of(buildPayloadDataFromRecords(weekly, records, prevRecords));
+    }
+
+    /**
      * 해당 사용자의 "이번 주" (오늘 기준 월~일 주) 기록으로 분석 데이터 문자열을 만듭니다.
      */
     @Transactional(readOnly = true)
@@ -45,8 +81,18 @@ public class WeeklyReportDataService {
         int year = getYearOfWeek(today);
         int month = getMonthOfWeek(today);
         int week = getWeekOfMonth(today);
+        return buildDataForAnalysis(userId, year, month, week);
+    }
 
+    /**
+     * 지정한 year, month, week에 해당하는 주간 기록으로 분석 데이터 문자열을 만듭니다.
+     */
+    @Transactional(readOnly = true)
+    public String buildDataForAnalysis(Long userId, int year, int month, int week) {
         Optional<Weekly> weeklyOpt = weeklyRepository.findByYearAndMonthAndWeek(year, month, week);
+        if (weeklyOpt.isEmpty()) {
+            throw new IllegalArgumentException("해당 주차 데이터가 없습니다: year=%d, month=%d, week=%d".formatted(year, month, week));
+        }
 
         List<Record> records = recordRepository.findByUserIdAndWeeklyIdIn(userId, List.of(weeklyOpt.get().getId()));
         return buildDataForAnalysisFromRecords(records);
@@ -63,6 +109,32 @@ public class WeeklyReportDataService {
     private static int getWeekOfMonth(LocalDate date) {
         LocalDate monday = date.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
         return (monday.getDayOfMonth() - 1) / 7 + 1;
+    }
+
+    /** 이전 주의 year, month, week 반환 */
+    private static int[] getPreviousWeek(int year, int month, int week) {
+        if (week > 1) {
+            return new int[]{year, month, week - 1};
+        }
+        if (month > 1) {
+            LocalDate lastDayOfPrevMonth = LocalDate.of(year, month, 1).minusDays(1);
+            int prevMonth = lastDayOfPrevMonth.getMonthValue();
+            int prevYear = lastDayOfPrevMonth.getYear();
+            int prevWeek = getWeekOfMonth(lastDayOfPrevMonth);
+            return new int[]{prevYear, prevMonth, prevWeek};
+        }
+        LocalDate lastDayOfPrevYear = LocalDate.of(year, 1, 1).minusDays(1);
+        return new int[]{
+                lastDayOfPrevYear.getYear(),
+                lastDayOfPrevYear.getMonthValue(),
+                getWeekOfMonth(lastDayOfPrevYear)
+        };
+    }
+
+    private static LocalDate getMondayOfWeek(int year, int month, int week) {
+        int dayOfMonth = (week - 1) * 7 + 1;
+        int maxDay = LocalDate.of(year, month, 1).lengthOfMonth();
+        return LocalDate.of(year, month, Math.min(dayOfMonth, maxDay));
     }
 
     private static Map<String, String> toEmotionWithCategory(Emotion emotion) {
@@ -189,4 +261,198 @@ public class WeeklyReportDataService {
         sb.append("  ### 지난 주 통계\n  {\"감정 분포\": {}, \"장르 분포\": {}}\n");
         return sb.toString();
     }
+
+    private WeeklyReportPayloadData buildPayloadDataFromRecords(Weekly weekly, List<Record> records, List<Record> prevRecords) {
+        LocalDate monday = getMondayOfWeek(weekly.getYear(), weekly.getMonth(), weekly.getWeek());
+
+        List<Map<String, String>> weeklyPlaylistMusics = new ArrayList<>();
+        Map<String, List<String>> emotionToGenres = new LinkedHashMap<>();
+        Map<String, List<String>> emotionToThumbnails = new LinkedHashMap<>();
+        Map<String, List<String>> situationToThumbnails = new LinkedHashMap<>();
+        List<String> allGenres = new ArrayList<>();
+        List<Map<String, String>> allEmotionsForTop = new ArrayList<>();
+
+        for (Record record : records) {
+            List<Map<String, String>> emotionsWithCategory = record.getEmotions().stream()
+                    .map(WeeklyReportDataService::toEmotionWithCategory)
+                    .toList();
+            allEmotionsForTop.addAll(emotionsWithCategory);
+
+            List<String> situations = record.getSituationsToString();
+            List<GetRecordMusicDto> musics = recordMusicRepository.findAllByRecordId(record.getId());
+
+            for (GetRecordMusicDto m : musics) {
+                String genre = (m.getGenre() != null && !m.getGenre().isBlank()) ? m.getGenre() : "미분류";
+                allGenres.add(genre);
+                String thumb = (m.getThumbnail() != null && !m.getThumbnail().isBlank()) ? m.getThumbnail() : "";
+
+                weeklyPlaylistMusics.add(Map.of(
+                        "title", m.getTitle() != null ? m.getTitle() : "",
+                        "artist", m.getArtist() != null ? m.getArtist() : "",
+                        "thumbnail", thumb));
+
+                for (Map<String, String> em : emotionsWithCategory) {
+                    String emotionVal = em.get("emotion");
+                    emotionToGenres.computeIfAbsent(emotionVal, k -> new ArrayList<>()).add(genre);
+                    if (!thumb.isBlank()) {
+                        emotionToThumbnails.computeIfAbsent(emotionVal, k -> new ArrayList<>()).add(thumb);
+                    }
+                }
+                for (String sit : situations) {
+                    if (!thumb.isBlank()) {
+                        situationToThumbnails.computeIfAbsent(sit, k -> new ArrayList<>()).add(thumb);
+                    }
+                }
+            }
+        }
+
+        List<List<Map<String, String>>> dailyEmotionTagsByDay = buildDailyEmotionTagsByDay(records, monday);
+        List<String> topEmotionTagsForSummary = buildTopEmotionTagsForSummary(allEmotionsForTop, 2);
+
+        Map<String, Long> emotionCountsThisWeek = allEmotionsForTop.stream()
+                .collect(Collectors.groupingBy(WeeklyReportDataService::emotionKey, Collectors.counting()));
+        Map<String, Long> genreCountsThisWeek = allGenres.stream()
+                .collect(Collectors.groupingBy(g -> g, Collectors.counting()));
+
+        List<Map<String, String>> prevEmotions = prevRecords.stream()
+                .flatMap(r -> r.getEmotions().stream().map(WeeklyReportDataService::toEmotionWithCategory))
+                .toList();
+        List<String> prevGenres = prevRecords.stream()
+                .flatMap(r -> recordMusicRepository.findAllByRecordId(r.getId()).stream())
+                .map(m -> (m.getGenre() != null && !m.getGenre().isBlank()) ? m.getGenre() : "미분류")
+                .toList();
+        Map<String, Long> emotionCountsPrevWeek = prevEmotions.stream()
+                .collect(Collectors.groupingBy(WeeklyReportDataService::emotionKey, Collectors.counting()));
+        Map<String, Long> genreCountsPrevWeek = prevGenres.stream()
+                .collect(Collectors.groupingBy(g -> g, Collectors.counting()));
+
+        List<Map<String, Object>> topEmotionGenreData = buildTopEmotionGenreData(emotionToGenres, emotionToThumbnails, emotionCountsThisWeek, 3);
+
+        Set<String> seen = new HashSet<>();
+        List<Map<String, String>> dedupedPlaylist = weeklyPlaylistMusics.stream()
+                .filter(m -> seen.add(m.get("title") + "|" + m.get("artist")))
+                .toList();
+
+        String topEmotion = computeComparisonEmotion(emotionCountsThisWeek, emotionCountsPrevWeek);
+        String topGenre = computeComparisonGenre(genreCountsThisWeek, genreCountsPrevWeek);
+
+        Map<String, List<String>> sortedSituationThumbnails = situationToThumbnails.entrySet().stream()
+                .sorted((a, b) -> Integer.compare(b.getValue().size(), a.getValue().size()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (a, b) -> a, LinkedHashMap::new));
+
+        return new WeeklyReportPayloadData(
+                weekly,
+                dedupedPlaylist,
+                dailyEmotionTagsByDay,
+                topEmotionTagsForSummary,
+                emotionToGenres,
+                emotionToThumbnails,
+                sortedSituationThumbnails,
+                topEmotion,
+                topGenre,
+                emotionCountsThisWeek,
+                genreCountsThisWeek,
+                emotionCountsPrevWeek,
+                genreCountsPrevWeek,
+                topEmotionGenreData);
+    }
+
+    private List<List<Map<String, String>>> buildDailyEmotionTagsByDay(List<Record> records, LocalDate monday) {
+        List<List<Map<String, String>>> result = new ArrayList<>();
+
+        for (int i = 0; i < 7; i++) {
+            LocalDate dayDate = monday.plusDays(i);
+            List<Map<String, String>> dayEmotions = records.stream()
+                    .filter(r -> r.getCreatedAt().toLocalDate().equals(dayDate))
+                    .flatMap(r -> r.getEmotions().stream().map(WeeklyReportDataService::toEmotionWithCategory))
+                    .filter(m -> !"미상".equals(m.get("emotion")))
+                    .map(m -> Map.of("category", m.get("category"), "value", m.get("emotion")))
+                    .distinct()
+                    .toList();
+            result.add(dayEmotions);
+        }
+        return result;
+    }
+
+    private List<String> buildTopEmotionTagsForSummary(List<Map<String, String>> allEmotions, int limit) {
+        return allEmotions.stream()
+                .collect(Collectors.groupingBy(WeeklyReportDataService::emotionKey, Collectors.counting()))
+                .entrySet().stream()
+                .filter(e -> !e.getKey().endsWith("|미상"))
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(limit)
+                .map(e -> e.getKey().split("\\|", 2)[1])
+                .toList();
+    }
+
+    private List<Map<String, Object>> buildTopEmotionGenreData(
+            Map<String, List<String>> emotionToGenres,
+            Map<String, List<String>> emotionToThumbnails,
+            Map<String, Long> emotionCountsThisWeek,
+            int limit) {
+        return emotionCountsThisWeek.entrySet().stream()
+                .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
+                .limit(limit * 2)
+                .filter(e -> !e.getKey().endsWith("|미상"))
+                .map(e -> {
+                    String[] parts = e.getKey().split("\\|", 2);
+                    String emotion = parts[1];
+                    List<String> genres = emotionToGenres.getOrDefault(emotion, List.of());
+                    List<String> thumbs = emotionToThumbnails.getOrDefault(emotion, List.of());
+                    if (genres.isEmpty() && thumbs.isEmpty()) {
+                        return null;
+                    }
+                    return Map.<String, Object>of(
+                            "emotion", emotion,
+                            "genres", dedupeList(genres),
+                            "thumbnail", dedupeList(thumbs));
+                })
+                .filter( m -> m != null)
+                .limit(limit)
+                .toList();
+    }
+
+    private static List<String> dedupeList(List<String> list) {
+        return list.stream().filter(s -> s != null && !s.isBlank()).distinct().toList();
+    }
+
+    private String computeComparisonEmotion(Map<String, Long> thisWeek, Map<String, Long> prevWeek) {
+        if (prevWeek.isEmpty()) {
+            return thisWeek.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(e -> e.getKey().split("\\|", 2)[1])
+                    .orElse("");
+        }
+        return thisWeek.entrySet().stream()
+                .map(e -> {
+                    long diff = e.getValue() - prevWeek.getOrDefault(e.getKey(), 0L);
+                    return Map.entry(e.getKey(), diff);
+                })
+                .filter(e -> e.getValue() > 0)
+                .max(Map.Entry.comparingByValue())
+                .map(e -> e.getKey().split("\\|", 2)[1])
+                .orElseGet(() -> thisWeek.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(x -> x.getKey().split("\\|", 2)[1])
+                        .orElse(""));
+    }
+
+    private String computeComparisonGenre(Map<String, Long> thisWeek, Map<String, Long> prevWeek) {
+        if (prevWeek.isEmpty()) {
+            return thisWeek.entrySet().stream()
+                    .max(Map.Entry.comparingByValue())
+                    .map(Map.Entry::getKey)
+                    .orElse("");
+        }
+        return thisWeek.entrySet().stream()
+                .map(e -> Map.entry(e.getKey(), e.getValue() - prevWeek.getOrDefault(e.getKey(), 0L)))
+                .filter(e -> e.getValue() > 0)
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElseGet(() -> thisWeek.entrySet().stream()
+                        .max(Map.Entry.comparingByValue())
+                        .map(Map.Entry::getKey)
+                        .orElse(""));
+    }
+
 }

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
@@ -109,17 +109,35 @@ public class WeeklyReportGenerationService {
                         .status(ReportStatus.CREATED)
                         .build()));
 
-        String dataForAnalysis = weeklyReportDataService.buildDataForAnalysis(userId, year, month, week);
-        String systemMessage = "당신은 음악 기록 서비스의 주간 분석 리포트를 생성하는 AI 어시스턴트입니다.\n"
-                + "사용자의 이번 주 음악 기록 데이터를 분석하여 따뜻하고 공감적인 문장들을 생성해주세요.\n"
-                + dataForAnalysis + "\n"
-                + DATA_FOR_CREATE_REPORT + "\n"
-                + OUTPUT_FORMAT;
+        if (report.getStatus() == ReportStatus.COMPLETED) {
+            log.info("이미 완료된 리포트입니다. userId={}, weeklyId={}", userId, weekly.getId());
+            return Optional.of(report);
+        }
+        if (report.getStatus() == ReportStatus.PROCESSING) {
+            log.warn("이미 처리 중인 리포트입니다. userId={}, weeklyId={}", userId, weekly.getId());
+            return Optional.empty();
+        }
 
-        String llmResponse = deepSeekReportClient.ask(systemMessage);
-        String mergedContent = weeklyReportMergeService.merge(llmResponse, payload);
+        report.startProcessing();
+        reportRepository.save(report);
 
-        report.complete(mergedContent);
-        return Optional.of(reportRepository.save(report));
+        try {
+            String dataForAnalysis = weeklyReportDataService.buildDataForAnalysis(userId, year, month, week);
+            String systemMessage = "당신은 음악 기록 서비스의 주간 분석 리포트를 생성하는 AI 어시스턴트입니다.\n"
+                    + "사용자의 이번 주 음악 기록 데이터를 분석하여 따뜻하고 공감적인 문장들을 생성해주세요.\n"
+                    + dataForAnalysis + "\n"
+                    + DATA_FOR_CREATE_REPORT + "\n"
+                    + OUTPUT_FORMAT;
+
+            String llmResponse = deepSeekReportClient.ask(systemMessage);
+            String mergedContent = weeklyReportMergeService.merge(llmResponse, payload);
+
+            report.complete(mergedContent);
+            return Optional.of(reportRepository.save(report));
+        } catch (Exception e) {
+            report.fail();
+            reportRepository.save(report);
+            throw e;
+        }
     }
 }

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
@@ -1,0 +1,125 @@
+package dalgrock.playlist.service;
+
+import dalgrock.playlist.infrastructure.deepseek.DeepSeekReportClient;
+import dalgrock.playlist.infrastructure.repository.ReportRepository;
+import dalgrock.playlist.model.Report;
+import dalgrock.playlist.model.ReportStatus;
+import dalgrock.playlist.service.dto.WeeklyReportPayloadData;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * 주간 리포트 생성 로직을 담당합니다.
+ * LLM 호출, 병합, DB 저장을 수행합니다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class WeeklyReportGenerationService {
+
+    private static final String DATA_FOR_CREATE_REPORT = """
+              ## 생성해야 할 항목
+              ### 1. overallSummary.title (주간 요약 타이틀)
+              
+              - 이번 주를 한 문장으로 요약 (최대 36자, 공백 포함)
+              - 주요 감정과 음악 장르를 포함
+              - 따뜻하고 공감적인 톤
+              - 이모지 사용 가능 (선택사항)
+              - 예시: "잔잔하고 외로웠던 이번 주, R&B와 함께했어요 ✨"
+              
+              ### 2. overallSummary.summaryTags (요약 태그)
+              
+              - 정확히 2개의 태그 생성
+              - 각 태그는 1~2단어
+              - 감정 상태나 음악 청취 패턴을 나타냄
+              - 예시: ["위로", "전환"]
+              
+              ### 3. weeklyEmotionSummary.title (이번 주 감정 요약)
+              
+              - 일별 감정 변화를 한 문장으로 요약
+              - 격려적이고 공감적인 톤
+              - 감정 회복이나 변화 과정을 강조
+              - 예시: "우울한 감정을 열심히 회복시켰어요"
+              
+              ### 4. emotionGenreDescriptions (감정-장르 분석 설명)
+              
+              - 각 감정-장르 조합에 대한 맞춤형 메시지
+              - "당신은 ~였어요" 형식
+              - 긍정적이고 격려적인 톤
+              - 해당 감정을 그 장르의 음악으로 해소한 사용자의 행동을 긍정적으로 해석
+              - 예시: "복잡미묘한 감정을 힙한 음악으로 해소한 당신은 분위기를 순식간에 바꾸는 반전 메이커였어요!"
+              
+              
+              ### 5. weeklyComparison.summary (지난 주와의 비교 요약)
+              
+              - 지난 주 대비 변화를 한 문장으로 요약
+              - 감정과 장르를 모두 포함
+              - 중립적이면서도 관찰적인 톤
+              - 예시: "지난 주에 비해 우울감을 더 많이 느끼고 팝 장르 음악을 많이 들은 한 주였어요"
+              
+              ### 6. weeklyComparison.nextWeekSuggestion (다음 주 제안)
+              
+              - 이번 주 분석을 바탕으로 다음 주 음악 감상 제안
+              - "~하는 건 어떨까요?" 형식 권장
+              - 격려적이고 제안하는 톤
+              - 구체적이면서도 부드러운 표현
+              - 예시: "다음 주에는 신나는 음악으로 기분을 전환해 보는 건 어떨까요?"
+              """;
+
+    private static final String OUTPUT_FORMAT = """
+              ## 출력 형식
+              
+              다음 JSON 형식으로 응답해주세요:
+              - overallSummary: { title, summaryTags }
+              - weeklyEmotionSummary: { title }
+              - emotionGenreDescriptions: [ { emotion, description }, ... ]
+              - weeklyComparison: { summary, nextWeekSuggestion }
+              """;
+
+    private final WeeklyReportDataService weeklyReportDataService;
+    private final WeeklyReportMergeService weeklyReportMergeService;
+    private final ReportRepository reportRepository;
+    private final DeepSeekReportClient deepSeekReportClient;
+
+    /**
+     * 지정한 year, month, week에 대해 사용자의 주간 리포트를 생성하고 DB에 저장합니다.
+     *
+     * @return 생성된 Report (없는 주차이거나 API 키 미설정 시 empty)
+     */
+    public Optional<Report> generateReport(Long userId, int year, int month, int week) {
+        if (!deepSeekReportClient.isConfigured()) {
+            log.warn("주간 리포트 스킵: deepseek.api-key가 설정되지 않았습니다.");
+            return Optional.empty();
+        }
+
+        var payloadOpt = weeklyReportDataService.getReportPayloadData(userId, year, month, week);
+        if (payloadOpt.isEmpty()) {
+            return Optional.empty();
+        }
+
+        WeeklyReportPayloadData payload = payloadOpt.get();
+        var weekly = payload.weekly();
+
+        Report report = reportRepository.findByUserIdAndWeeklyId(userId, weekly.getId())
+                .orElseGet(() -> reportRepository.save(Report.builder()
+                        .userId(userId)
+                        .weekly(weekly)
+                        .status(ReportStatus.CREATED)
+                        .build()));
+
+        String dataForAnalysis = weeklyReportDataService.buildDataForAnalysis(userId, year, month, week);
+        String systemMessage = "당신은 음악 기록 서비스의 주간 분석 리포트를 생성하는 AI 어시스턴트입니다.\n"
+                + "사용자의 이번 주 음악 기록 데이터를 분석하여 따뜻하고 공감적인 문장들을 생성해주세요.\n"
+                + dataForAnalysis + "\n"
+                + DATA_FOR_CREATE_REPORT + "\n"
+                + OUTPUT_FORMAT;
+
+        String llmResponse = deepSeekReportClient.ask(systemMessage);
+        String mergedContent = weeklyReportMergeService.merge(llmResponse, payload);
+
+        report.complete(mergedContent);
+        return Optional.of(reportRepository.save(report));
+    }
+}

--- a/src/main/java/dalgrock/playlist/service/WeeklyReportMergeService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportMergeService.java
@@ -1,0 +1,169 @@
+package dalgrock.playlist.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import dalgrock.playlist.service.dto.WeeklyReportPayloadData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+/**
+ * LLM 응답과 Record 기반 데이터를 병합하여 최종 리포트 JSON을 생성합니다.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class WeeklyReportMergeService {
+
+    private static final Pattern JSON_BLOCK = Pattern.compile("```(?:json)?\\s*([\\s\\S]*?)```");
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * LLM JSON 문자열과 Record 기반 페이로드 데이터를 병합하여 최종 리포트 JSON 문자열을 반환합니다.
+     */
+    public String merge(String llmResponse, WeeklyReportPayloadData payload) {
+        JsonNode llmRoot = parseLlmJson(llmResponse);
+
+        ObjectNode result = objectMapper.createObjectNode();
+
+        result.set("overallSummary", buildOverallSummary(llmRoot, payload));
+        result.set("weeklyPlaylist", buildWeeklyPlaylist(payload));
+        result.set("weeklyEmotionSummary", buildWeeklyEmotionSummary(llmRoot, payload));
+        result.set("emotionGenreDescriptions", buildEmotionGenreDescriptions(llmRoot, payload));
+        result.set("contextSummaries", buildContextSummaries(payload));
+        result.set("weeklyComparison", buildWeeklyComparison(llmRoot, payload));
+
+        try {
+            return objectMapper.writeValueAsString(result);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException("리포트 JSON 직렬화 실패", e);
+        }
+    }
+
+    private JsonNode parseLlmJson(String llmResponse) {
+        String json = llmResponse.trim();
+        Matcher m = JSON_BLOCK.matcher(json);
+        if (m.find()) {
+            json = m.group(1).trim();
+        }
+        try {
+            return objectMapper.readTree(json);
+        } catch (JsonProcessingException e) {
+            log.warn("LLM 응답 JSON 파싱 실패, 원본 사용: {}", e.getMessage());
+            throw new IllegalArgumentException("LLM 응답 JSON 파싱 실패", e);
+        }
+    }
+
+    private ObjectNode buildOverallSummary(JsonNode llmRoot, WeeklyReportPayloadData payload) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.set("title", llmRoot.path("overallSummary").path("title"));
+        ArrayNode tags = objectMapper.createArrayNode();
+        List<String> tagList = payload.topEmotionTagsForSummary();
+        if (tagList.isEmpty()) {
+            tags.add("미상");
+        } else {
+            for (String value : tagList) {
+                tags.add(value);
+            }
+        }
+        node.set("summaryTags", tags);
+        return node;
+    }
+
+    private ObjectNode buildWeeklyPlaylist(WeeklyReportPayloadData payload) {
+        ObjectNode node = objectMapper.createObjectNode();
+        ArrayNode musics = objectMapper.createArrayNode();
+        for (Map<String, String> m : payload.weeklyPlaylistMusics()) {
+            ObjectNode music = objectMapper.createObjectNode();
+            music.put("title", m.getOrDefault("title", ""));
+            music.put("artist", m.getOrDefault("artist", ""));
+            music.put("thumbnail", m.getOrDefault("thumbnail", ""));
+            musics.add(music);
+        }
+        node.set("musics", musics);
+        return node;
+    }
+
+    private ObjectNode buildWeeklyEmotionSummary(JsonNode llmRoot, WeeklyReportPayloadData payload) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.set("title", llmRoot.path("weeklyEmotionSummary").path("title"));
+
+        ArrayNode tags = objectMapper.createArrayNode();
+        for (List<Map<String, String>> day : payload.dailyEmotionTagsByDay()) {
+            ArrayNode dayArr = objectMapper.createArrayNode();
+            for (Map<String, String> t : day) {
+                ObjectNode tag = objectMapper.createObjectNode();
+                tag.put("category", t.getOrDefault("category", ""));
+                tag.put("value", t.getOrDefault("value", ""));
+                dayArr.add(tag);
+            }
+            tags.add(dayArr);
+        }
+        node.set("tags", tags);
+        return node;
+    }
+
+    private ArrayNode buildEmotionGenreDescriptions(JsonNode llmRoot, WeeklyReportPayloadData payload) {
+        ArrayNode result = objectMapper.createArrayNode();
+        List<Map<String, Object>> topData = payload.topEmotionGenreData();
+
+        for (Map<String, Object> data : topData) {
+            String emotion = (String) data.get("emotion");
+            @SuppressWarnings("unchecked")
+            List<String> genres = (List<String>) data.getOrDefault("genres", List.of());
+            @SuppressWarnings("unchecked")
+            List<String> thumbnails = (List<String>) data.getOrDefault("thumbnail", List.of());
+
+            String description = findDescriptionForEmotion(llmRoot, emotion);
+
+            ObjectNode merged = objectMapper.createObjectNode();
+            merged.put("emotion", emotion);
+            merged.put("description", description);
+            merged.set("genres", objectMapper.valueToTree(genres));
+            merged.set("thumbnail", objectMapper.valueToTree(thumbnails));
+            result.add(merged);
+        }
+        return result;
+    }
+
+    private String findDescriptionForEmotion(JsonNode llmRoot, String emotion) {
+        JsonNode llmItems = llmRoot.path("emotionGenreDescriptions");
+        if (!llmItems.isArray()) {
+            return "";
+        }
+        for (JsonNode item : llmItems) {
+            if (emotion.equals(item.path("emotion").asText(""))) {
+                return item.path("description").asText("");
+            }
+        }
+        return "";
+    }
+
+    private ArrayNode buildContextSummaries(WeeklyReportPayloadData payload) {
+        ArrayNode result = objectMapper.createArrayNode();
+        for (Map.Entry<String, List<String>> e : payload.situationToThumbnails().entrySet()) {
+            ObjectNode node = objectMapper.createObjectNode();
+            node.put("value", e.getKey());
+            node.set("thumbnail", objectMapper.valueToTree(e.getValue()));
+            result.add(node);
+        }
+        return result;
+    }
+
+    private ObjectNode buildWeeklyComparison(JsonNode llmRoot, WeeklyReportPayloadData payload) {
+        ObjectNode node = objectMapper.createObjectNode();
+        node.put("emotion", payload.topEmotion());
+        node.put("genre", payload.topGenre());
+        node.set("nextWeekSuggestion", llmRoot.path("weeklyComparison").path("nextWeekSuggestion"));
+        return node;
+    }
+}

--- a/src/main/java/dalgrock/playlist/service/dto/WeeklyReportPayloadData.java
+++ b/src/main/java/dalgrock/playlist/service/dto/WeeklyReportPayloadData.java
@@ -1,0 +1,34 @@
+package dalgrock.playlist.service.dto;
+
+import dalgrock.playlist.model.Weekly;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 주간 리포트 병합에 필요한 Record 기반 데이터.
+ */
+public record WeeklyReportPayloadData(
+        Weekly weekly,
+        List<Map<String, String>> weeklyPlaylistMusics,
+        /** 요일별(월~일 7개) 감정 태그. 기록 없는 날은 빈 리스트 */
+        List<List<Map<String, String>>> dailyEmotionTagsByDay,
+        /** summaryTags용 상위 2개 감정 value (예: ["위로", "전환"]) */
+        List<String> topEmotionTagsForSummary,
+        Map<String, List<String>> emotionToGenres,
+        Map<String, List<String>> emotionToThumbnails,
+        /** 상황별 썸네일 (썸네일 개수 내림차순 정렬용) */
+        Map<String, List<String>> situationToThumbnails,
+        String topEmotion,
+        String topGenre,
+        /** 이번 주 감정별 카운트 (emotion display value -> count) */
+        Map<String, Long> emotionCountsThisWeek,
+        /** 이번 주 장르별 카운트 */
+        Map<String, Long> genreCountsThisWeek,
+        /** 지난 주 감정별 카운트 (없으면 empty) */
+        Map<String, Long> emotionCountsPrevWeek,
+        /** 지난 주 장르별 카운트 (없으면 empty) */
+        Map<String, Long> genreCountsPrevWeek,
+        /** LLM emotionGenreDescriptions용: 감정별 {genres, thumbnails}가 있는 상위 3개 감정 */
+        List<Map<String, Object>> topEmotionGenreData
+) {
+}

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetReportResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetReportResponse.java
@@ -1,0 +1,21 @@
+package dalgrock.playlist.service.dto.response;
+
+import java.util.List;
+
+public record GetReportResponse(
+        int year,
+        int month,
+        List<WeeklyReportItem> weekly
+) {
+
+    public record WeeklyReportItem(
+            int week,
+            Long reportId,
+            String status,
+            String title,
+            int recordCount,
+            List<String> emotions,
+            String representativeThumbnail,
+            List<String> thumbnails
+    ) {}
+}

--- a/src/main/resources/application-local.yaml
+++ b/src/main/resources/application-local.yaml
@@ -6,7 +6,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: validate
+      ddl-auto: update
     defer-datasource-initialization: true
     show-sql: true
     properties:
@@ -54,14 +54,14 @@ jwt:
 
 app:
   api:
-    server-url: "http://localhost:8080"
+    server-url: 'http://localhost:8080'
   auth:
     host: https://pliview.kr
     redirect-uri: https://pliview.kr/auth/kakao/callback
     secure-cookie: false
     samesite-cookie: None
   cors:
-    allowed-origins: "https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,http://127.0.0.1:8080,https://dev.pliview.kr:5173,https://*.pliview.kr"
+    allowed-origins: 'https://pliview.kr,https://api-dev.pliview.kr,http://api-dev.pliview.kr,http://localhost:8080,http://localhost:3000,http://localhost:5173,http://127.0.0.1:8080,https://dev.pliview.kr:5173,https://*.pliview.kr'
 
 spotify:
   client-id: ${SPOTIFY_CLIENT_ID}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -84,6 +84,10 @@ spotify:
   client-id: ${SPOTIFY_CLIENT_ID}
   client-secret: ${SPOTIFY_CLIENT_SECRET}
 
+deepseek:
+  api-key: ${DEEPSEEK_API_KEY:}
+  api-url: https://api.deepseek.com/chat/completions
+
 client:
   connection-timeout: 5
   read-timeout: 10

--- a/src/main/resources/db/add-content-to-reports.sql
+++ b/src/main/resources/db/add-content-to-reports.sql
@@ -1,0 +1,2 @@
+-- Add content column for report JSON payload (run manually if needed)
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS content TEXT;

--- a/src/main/resources/seed-user1-records.sql
+++ b/src/main/resources/seed-user1-records.sql
@@ -5,9 +5,9 @@
 --    주차: year, month, week (월요일 시작 기준)
 INSERT INTO weekly (id, title, year, month, week, created_at, updated_at)
 VALUES
-  (100, '2026년 2월 2주차', 2026, 2, 2, NOW(), NOW()),
-  (101, '2026년 2월 1주차', 2026, 2, 1, NOW(), NOW()),
-  (102, '2026년 1월 4주차', 2026, 1, 4, NOW(), NOW())
+  (100, '2026년 2월 4주차', 2026, 2, 4, NOW(), NOW()),
+  (101, '2026년 2월 3주차', 2026, 2, 3, NOW(), NOW()),
+  (102, '2026년 2월 2주차', 2026, 2, 2, NOW(), NOW())
 ON CONFLICT DO NOTHING;
 
 -- 2) Records: 이번주 1개, 저번주 5개, 저저번주 6개 (user_id = 1)
@@ -15,73 +15,77 @@ INSERT INTO records (id, user_id, weekly_id, thumbnail, location, content, creat
 VALUES
   (200, 1, 100, 'https://example.com/thumb1.png', '서울', '이번주 기록 내용', NOW() - INTERVAL '2 days', NOW() - INTERVAL '2 days'),
   (201, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 1', NOW() - INTERVAL '9 days', NOW() - INTERVAL '9 days'),
-  (202, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 2', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days'),
-  (203, 1, 101, 'https://example.com/thumb2.png', '퇴근길', '저번주 기록 3', NOW() - INTERVAL '7 days', NOW() - INTERVAL '7 days'),
-  (204, 1, 101, 'https://example.com/thumb2.png', '카페', '저번주 기록 4', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days'),
-  (205, 1, 101, 'https://example.com/thumb2.png', '부산', '저번주 기록 5', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days'),
-  (206, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 1', NOW() - INTERVAL '16 days', NOW() - INTERVAL '16 days'),
-  (207, 1, 102, 'https://example.com/thumb3.png', '회사', '저저번주 기록 2', NOW() - INTERVAL '15 days', NOW() - INTERVAL '15 days'),
-  (208, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 3', NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
-  (209, 1, 102, 'https://example.com/thumb3.png', '부산', '저저번주 기록 4', NOW() - INTERVAL '13 days', NOW() - INTERVAL '13 days'),
-  (210, 1, 102, 'https://example.com/thumb3.png', '카페', '저저번주 기록 5', NOW() - INTERVAL '12 days', NOW() - INTERVAL '12 days'),
-  (211, 1, 102, 'https://example.com/thumb3.png', '버스', '저저번주 기록 6', NOW() - INTERVAL '11 days', NOW() - INTERVAL '11 days')
+  (202, 1, 101, 'https://example.com/thumb3.png', '카페', '저번주 기록 2', NOW() - INTERVAL '8 days', NOW() - INTERVAL '8 days'),
+  (203, 1, 101, 'https://example.com/thumb4.png', '퇴근길', '저번주 기록 3', NOW() - INTERVAL '7 days', NOW() - INTERVAL '7 days'),
+  (204, 1, 101, 'https://example.com/thumb5.png', '카페', '저번주 기록 4', NOW() - INTERVAL '6 days', NOW() - INTERVAL '6 days'),
+  (205, 1, 101, 'https://example.com/thumb6.png', '부산', '저번주 기록 5', NOW() - INTERVAL '5 days', NOW() - INTERVAL '5 days'),
+  (206, 1, 102, 'https://example.com/thumb7.png', '버스', '저저번주 기록 1', NOW() - INTERVAL '16 days', NOW() - INTERVAL '16 days'),
+  (207, 1, 102, 'https://example.com/thumb8.png', '회사', '저저번주 기록 2', NOW() - INTERVAL '15 days', NOW() - INTERVAL '15 days'),
+  (208, 1, 102, 'https://example.com/thumb9.png', '버스', '저저번주 기록 3', NOW() - INTERVAL '14 days', NOW() - INTERVAL '14 days'),
+  (209, 1, 102, 'https://example.com/thumb10.png', '부산', '저저번주 기록 4', NOW() - INTERVAL '13 days', NOW() - INTERVAL '13 days'),
+  (210, 1, 102, 'https://example.com/thumb11.png', '카페', '저저번주 기록 5', NOW() - INTERVAL '12 days', NOW() - INTERVAL '12 days'),
+  (211, 1, 102, 'https://example.com/thumb12.png', '버스', '저저번주 기록 6', NOW() - INTERVAL '11 days', NOW() - INTERVAL '11 days')
 ON CONFLICT DO NOTHING;
 
 -- 3) Emotions (record_id 200~211)
-INSERT INTO emotions (record_id, category, value)
+-- category 컬럼 없음. value는 EmotionValue 한글 표시값 또는 enum 이름 사용
+INSERT INTO emotions (record_id, value)
 VALUES
   (200, '기쁨'),
   (200, '설렘'),
-  (201, '평온'),
   (201, '감사'),
+  (201, '행복'),
   (202, '신남'),
-  (202, '기대'),
+  (202, '설렘'),
   (203, '행복'),
-  (203, '편안'),
+  (203, '뿌듯함'),
   (204, '설렘'),
   (204, '기쁨'),
   (205, '감사'),
-  (205, '평온'),
+  (205, '행복'),
   (206, '신남'),
-  (206, '기대'),
+  (206, '설렘'),
   (207, '행복'),
-  (207, '편안'),
+  (207, '뿌듯함'),
   (208, '설렘'),
   (208, '기쁨'),
   (209, '감사'),
-  (209, '평온'),
+  (209, '행복'),
   (210, '신남'),
-  (210, '기대'),
+  (210, '설렘'),
   (211, '행복'),
-  (211, '편안');
+  (211, '뿌듯함')
+ON CONFLICT DO NOTHING;
 
 -- 4) Situations (record_id 200~211)
-INSERT INTO situations (record_id, category, value)
+-- category 컬럼 없음. value는 SituationValue 한글 표시값 또는 enum 이름 사용
+INSERT INTO situations (record_id, value)
 VALUES
-  (200, '출퇴근'),
-  (200, '휴식'),
+  (200, '퇴근길'),
+  (200, '낮잠'),
   (201, '운동'),
   (201, '독서'),
-  (202, '여행'),
-  (202, '맛집'),
-  (203, '출퇴근'),
-  (203, '휴식'),
+  (202, '드라이브'),
+  (202, '산책'),
+  (203, '퇴근길'),
+  (203, '낮잠'),
   (204, '운동'),
   (204, '독서'),
-  (205, '여행'),
-  (205, '맛집'),
-  (206, '출퇴근'),
-  (206, '휴식'),
+  (205, '드라이브'),
+  (205, '산책'),
+  (206, '퇴근길'),
+  (206, '낮잠'),
   (207, '운동'),
   (207, '독서'),
-  (208, '여행'),
-  (208, '맛집'),
-  (209, '출퇴근'),
-  (209, '휴식'),
+  (208, '드라이브'),
+  (208, '산책'),
+  (209, '퇴근길'),
+  (209, '낮잠'),
   (210, '운동'),
   (210, '독서'),
-  (211, '여행'),
-  (211, '맛집');
+  (211, '드라이브'),
+  (211, '산책')
+ON CONFLICT DO NOTHING;
 
 -- 5) 시퀀스 갱신 (다음 INSERT 시 id 충돌 방지, 이미 사용 중인 max id보다 크게)
 SELECT setval(pg_get_serial_sequence('weekly', 'id'), (SELECT COALESCE(MAX(id), 1) FROM weekly));


### PR DESCRIPTION
## Issue Number

closed #41 

## As is

- 주간 리포트가 생성되지 않았습니다.

## To be

- 딥시크API를 사용하여 주간 리포트를 분석합니다.
- 매주 일요일 오후6시 주간 리포트를 생성합니다. 
- 주간 리포트 분석 여부를 확인하여 월별 주간 리포트 목록을 역순 조회합니다. 

## Additional Description

### 썸네일 생성 전략

프론트엔드 디자인 컴포넌트상 '대표 썸네일 1개'와 '하단 서브 썸네일 4개'가 반드시 필요함에 따라, 서버에서 이를 무조건 5개(1+4)로 맞추어 응답하도록 설계했습니다.

- 대표 썸네일 (representativeThumbnail): 주간 분석 결과에서 가장 핵심적인 음악 앨범 아트를 선정함.
- 서브 썸네일 배열 (thumbnails):
  - 해당 주차에 기록된 사진이 4개 미만일 경우, 대표 썸네일을 중복 활용하여 배열의 길이를 무조건 4로 유지함.
  - 이를 통해 프론트엔드에서 데이터 개수에 따른 별도의 예외 처리 없이 일관된 레이아웃 렌더링이 가능해짐.
