### PR TITLE
refactor: 기간이 지난 미완성 리포트 미노출되도록 수정

### DIFF
--- a/src/main/java/dalgrock/playlist/service/ReportService.java
+++ b/src/main/java/dalgrock/playlist/service/ReportService.java
@@ -10,6 +10,10 @@ import dalgrock.playlist.model.Report;
 import dalgrock.playlist.model.ReportStatus;
 import dalgrock.playlist.model.Weekly;
 import dalgrock.playlist.service.dto.response.GetReportResponse;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -23,6 +27,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 @Service
 public class ReportService {
+
+    private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
 
     private final WeeklyRepository weeklyRepository;
     private final RecordRepository recordRepository;
@@ -45,20 +51,25 @@ public class ReportService {
         Map<Long, Report> reportByWeeklyId = allReports.stream()
                 .collect(Collectors.toMap(r -> r.getWeekly().getId(), r -> r, (a, b) -> a));
 
+        LocalDate currentWeekMonday = LocalDate.now(APP_ZONE)
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+
         List<GetReportResponse.WeeklyReportItem> items = weeklies.stream()
                 .sorted(Comparator.comparingInt(Weekly::getWeek).reversed())
                 .map(weekly -> buildWeeklyItem(
                         weekly,
                         recordsByWeeklyId.getOrDefault(weekly.getId(), List.of()),
-                        reportByWeeklyId.get(weekly.getId())
+                        reportByWeeklyId.get(weekly.getId()),
+                        currentWeekMonday
                 ))
+                .filter(item -> "COMPLETED".equals(item.status()) || "ANALYZING".equals(item.status()))
                 .toList();
 
         return new GetReportResponse(year, month, items);
     }
 
     private GetReportResponse.WeeklyReportItem buildWeeklyItem(
-            Weekly weekly, List<Record> records, Report report) {
+            Weekly weekly, List<Record> records, Report report, LocalDate currentWeekMonday) {
 
         int recordCount = records.size();
 
@@ -82,13 +93,40 @@ public class ReportService {
             );
         }
 
+        if (records.isEmpty()) {
+            return new GetReportResponse.WeeklyReportItem(
+                    weekly.getWeek(), null, "EMPTY",
+                    null, 0, List.of(), null, List.of()
+            );
+        }
+
         List<String> emotions = extractEmotionsFromRecords(records);
-        Long reportId = report != null ? report.getId() : null;
+        LocalDate weeklyMonday = getWeeklyMonday(weekly);
+
+        if (!weeklyMonday.isBefore(currentWeekMonday)) {
+            Long reportId = report != null ? report.getId() : null;
+            return new GetReportResponse.WeeklyReportItem(
+                    weekly.getWeek(), reportId, "ANALYZING",
+                    null, recordCount, emotions,
+                    representativeThumbnail, thumbnails
+            );
+        }
+
+        // 과거 주차이며 기록이 있지만 완료된 리포트가 없음 → EXPIRED
         return new GetReportResponse.WeeklyReportItem(
-                weekly.getWeek(), reportId, "ANALYZING",
+                weekly.getWeek(), null, "EXPIRED",
                 null, recordCount, emotions,
                 representativeThumbnail, thumbnails
         );
+    }
+
+    /**
+     * Weekly(year, month, week)에 해당하는 월요일을 반환합니다.
+     * week 번호는 해당 월요일의 dayOfMonth 기준: (dayOfMonth - 1) / 7 + 1
+     */
+    private LocalDate getWeeklyMonday(Weekly weekly) {
+        LocalDate firstDayOfBucket = LocalDate.of(weekly.getYear(), weekly.getMonth(), (weekly.getWeek() - 1) * 7 + 1);
+        return firstDayOfBucket.with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY));
     }
 
     /**


### PR DESCRIPTION
## Issue Number 

closed #51 

## As is

- 기간이 지났지만 미완성된 리포트들이 그대로 노출되어 주간리포트 조회 시 사용자가 혼란을 겪을 여지가 생겼습니다. 

## To be

- 기간이 지났음에도 미완성된 리포트를 조회 결과에서 제외합니다.


## Additional Description 

### 리포트 상태 판단

**[문제]**
리포트 데이터 존재 여부로만 상태를 판단할 경우, 분석 주기(Batch)를 놓친 과거 기록들이 현재 진행 중인 주차와 동일하게 '분석 중'으로 표시되어 사용자에게 혼란을 주는 이슈가 발생했습니다. 

**[해결방안]**
현재 시간과 기록 존재 여부를 결합하여 각 주차의 상태를 명확히 정의하고자 했습니다. 

**[상태]**

상태값 | 판단 로직 (Condition) | UI/UX 기대 효과 | 노출여부
-- | -- | -- | --
COMPLETED | Report 테이블에 데이터가 존재 | 분석된 타이틀과 요약 감정을 노출하여 상세 페이지 진입 허용 | 노출
ANALYZING | 리포트가 없고, 해당 주차가 **이번 주** | "분석 중" 그래픽과 함께 실시간 기록 수집 상태를 시각화 | 노출
EXPIRED | 리포트가 없고, 해당 주차가 **지난 주 이전** | 분석 기한이 지났음을 트래킹 | 미노출
EMPTY | 해당 주차에 사용자가 남긴 Record가 없음 | - | 미노출

DB에 저장된 상태값이 아닌, API 요청 시점에 현재 날짜와 데이터 존재 여부를 비교하여 동적으로 Status를 결정합니다.
서버 타임존을 기준으로 매주 월요일 00:00:00을 주차의 시작으로 정의하여 '이번 주' 여부를 판별합니다.
