### PR TITLE
기록 추가/조회 로직 수정

### DIFF
--- a/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
+++ b/src/main/java/dalgrock/playlist/controller/RecordControllerV1.java
@@ -62,12 +62,15 @@ public class RecordControllerV1 {
         return recordService.getRecordDetail(principal.userId(), recordId);
     }
 
-    @Operation(summary = "내 기록 추가", description = "오늘의 내 기록을 추가합니다")
+    @Operation(
+            summary = "내 기록 추가",
+            description = "기록을 추가합니다. 날짜는 year, month, day를 각각 숫자로 보냅니다(예: 2026, 2, 21). 셋 중 하나라도 없으면 오늘 날짜로 등록됩니다."
+    )
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     public CreateRecordResponse createRecord(
             @AuthenticationPrincipal UserPrincipal principal,
-            @RequestBody CreateRecordRequest request
+            @RequestBody @Valid CreateRecordRequest request
     ) {
         CreateRecordCommand command = toCommand(request);
         return recordService.createRecord(principal.userId(), command);
@@ -87,7 +90,10 @@ public class RecordControllerV1 {
                 request.emotions(),
                 request.content(),
                 request.situations(),
-                request.location()
+                request.location(),
+                request.year(),
+                request.month(),
+                request.day()
         );
     }
 

--- a/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
+++ b/src/main/java/dalgrock/playlist/controller/dto/request/CreateRecordRequest.java
@@ -1,5 +1,8 @@
 package dalgrock.playlist.controller.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.util.List;
@@ -17,7 +20,22 @@ public record CreateRecordRequest(
 
         List<String> situations,
 
-        String location
+        String location,
+
+        @Schema(description = "기록 날짜(년). 옵셔널. year/month/day 셋 다 있으면 해당 날짜, 하나라도 없으면 오늘. 예: 2026", example = "2026")
+        @Min(1900)
+        @Max(2100)
+        Integer year,
+
+        @Schema(description = "기록 날짜(월). 옵셔널. 1~12", example = "2")
+        @Min(1)
+        @Max(12)
+        Integer month,
+
+        @Schema(description = "기록 날짜(일). 옵셔널. 1~31", example = "21")
+        @Min(1)
+        @Max(31)
+        Integer day
 ) {
 
     public record Music(

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/RecordRepository.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.infrastructure.repository;
 
 import dalgrock.playlist.model.Record;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -12,6 +13,10 @@ public interface RecordRepository {
     Record save(Record record);
 
     boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByUserIdAndRecordDate(Long userId, LocalDate recordDate);
+
+    boolean existsByUserIdAndRecordDateIsNullAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end);
 
     List<Record> findByUserIdAndWeeklyIdIn(Long userId, List<Long> weeklyIds);
 }

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/JpaRecordRepository.java
@@ -1,6 +1,7 @@
 package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.model.Record;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,6 +11,10 @@ import org.springframework.data.repository.query.Param;
 public interface JpaRecordRepository extends JpaRepository<Record, Long> {
 
     boolean existsByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(Long userId, LocalDateTime start, LocalDateTime end);
+
+    boolean existsByUserIdAndRecordDateAndDeletedAtIsNull(Long userId, LocalDate recordDate);
+
+    boolean existsByUserIdAndRecordDateIsNullAndCreatedAtBetweenAndDeletedAtIsNull(Long userId, LocalDateTime start, LocalDateTime end);
 
     @Query("SELECT r FROM records r JOIN FETCH r.weekly WHERE r.userId = :userId AND r.weekly.id IN :weeklyIds AND r.deletedAt IS NULL")
     List<Record> findByUserIdAndWeeklyIdInFetchWeekly(@Param("userId") Long userId, @Param("weeklyIds") List<Long> weeklyIds);

--- a/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
+++ b/src/main/java/dalgrock/playlist/infrastructure/repository/jpa/RecordRepositoryAdapter.java
@@ -2,6 +2,7 @@ package dalgrock.playlist.infrastructure.repository.jpa;
 
 import dalgrock.playlist.infrastructure.repository.RecordRepository;
 import dalgrock.playlist.model.Record;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -27,6 +28,16 @@ public class RecordRepositoryAdapter implements RecordRepository {
     @Override
     public boolean existsByUserIdAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end) {
         return jpaRecordRepository.existsByUserIdAndCreatedAtBetweenAndDeletedAtIsNull(userId, start, end);
+    }
+
+    @Override
+    public boolean existsByUserIdAndRecordDate(Long userId, LocalDate recordDate) {
+        return jpaRecordRepository.existsByUserIdAndRecordDateAndDeletedAtIsNull(userId, recordDate);
+    }
+
+    @Override
+    public boolean existsByUserIdAndRecordDateIsNullAndCreatedAtBetween(Long userId, LocalDateTime start, LocalDateTime end) {
+        return jpaRecordRepository.existsByUserIdAndRecordDateIsNullAndCreatedAtBetweenAndDeletedAtIsNull(userId, start, end);
     }
 
     @Override

--- a/src/main/java/dalgrock/playlist/model/Record.java
+++ b/src/main/java/dalgrock/playlist/model/Record.java
@@ -17,6 +17,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,9 @@ public class Record extends BaseTimeEntity {
 
     @Column(name = "user_id", nullable = false)
     private Long userId;
+
+    @Column(name = "record_date")
+    private LocalDate recordDate;
 
     @ElementCollection(fetch = FetchType.LAZY)
     @CollectionTable(

--- a/src/main/java/dalgrock/playlist/service/RecordService.java
+++ b/src/main/java/dalgrock/playlist/service/RecordService.java
@@ -63,7 +63,29 @@ public class RecordService {
                 .map(GetRecordMusicResponse::from)
                 .toList();
 
-        return GetRecordDetailResponse.of(record, recordMusicResponses);
+        LocalDate recordDate = resolveRecordDate(record);
+        return GetRecordDetailResponse.of(recordDate, record, recordMusicResponses);
+    }
+
+    private static LocalDate resolveRecordDate(Record record) {
+        if (record.getRecordDate() != null) {
+            return record.getRecordDate();
+        }
+        return record.getCreatedAt().atZone(APP_ZONE).toLocalDate();
+    }
+
+    /**
+     * 년/월/일이 셋 다 있으면 해당 날짜, 하나라도 없거나 유효하지 않으면 today 사용.
+     */
+    private static LocalDate resolveTargetDate(Integer year, Integer month, Integer day, LocalDate today) {
+        if (year == null || month == null || day == null) {
+            return today;
+        }
+        try {
+            return LocalDate.of(year, month, day);
+        } catch (Exception e) {
+            return today;
+        }
     }
 
     private static final ZoneId APP_ZONE = ZoneId.of("Asia/Seoul");
@@ -92,8 +114,8 @@ public class RecordService {
 
         Map<LocalDate, Record> recordByDate = new HashMap<>();
         for (Record r : records) {
-            if (isDateInRange(r.getCreatedAt(), weekMonday, weekSunday)) {
-                LocalDate d = r.getCreatedAt().atZone(APP_ZONE).toLocalDate();
+            LocalDate d = resolveRecordDate(r);
+            if (!d.isBefore(weekMonday) && !d.isAfter(weekSunday)) {
                 recordByDate.put(d, r);
             }
         }
@@ -113,14 +135,6 @@ public class RecordService {
 
     private static GetRecordResponse.RecordItem emptyRecordItem(boolean isToday) {
         return new GetRecordResponse.RecordItem(null, null, List.of(), List.of(), isToday);
-    }
-
-    /**
-     * createdAt의 날짜가 [weekMonday, weekSunday] 안에 있는지 검사. 저장이 KST면 atZone(APP_ZONE), UTC면 UTC→Seoul 변환 필요.
-     */
-    private static boolean isDateInRange(LocalDateTime createdAt, LocalDate weekMonday, LocalDate weekSunday) {
-        LocalDate d = createdAt.atZone(APP_ZONE).toLocalDate();
-        return !d.isBefore(weekMonday) && !d.isAfter(weekSunday);
     }
 
     private GetRecordResponse.RecordItem toRecordItem(Record record, boolean isToday) {
@@ -145,16 +159,21 @@ public class RecordService {
     @Transactional
     public CreateRecordResponse createRecord(Long userId, CreateRecordCommand command) {
         LocalDate today = ZonedDateTime.now(APP_ZONE).toLocalDate();
-        LocalDateTime startOfDay = today.atStartOfDay();
-        LocalDateTime startOfNextDay = today.plusDays(1).atStartOfDay();
+        LocalDate targetDate = resolveTargetDate(command.year(), command.month(), command.day(), today);
 
-        if (recordRepository.existsByUserIdAndCreatedAtBetween(userId, startOfDay, startOfNextDay)) {
+        boolean existsByRecordDate = recordRepository.existsByUserIdAndRecordDate(userId, targetDate);
+        boolean existsByCreatedAt = recordRepository.existsByUserIdAndRecordDateIsNullAndCreatedAtBetween(
+                userId,
+                targetDate.atStartOfDay(),
+                targetDate.plusDays(1).atStartOfDay()
+        );
+        if (existsByRecordDate || existsByCreatedAt) {
             throw new RecordAlreadyExistsTodayException();
         }
 
-        int year = getYearOfWeek(today);
-        int month = getMonthOfWeek(today);
-        int week = getWeekOfMonth(today);
+        int year = getYearOfWeek(targetDate);
+        int month = getMonthOfWeek(targetDate);
+        int week = getWeekOfMonth(targetDate);
 
         Weekly weekly = findOrCreateWeekly(year, month, week);
 
@@ -167,6 +186,7 @@ public class RecordService {
 
         Record record = Record.builder()
                 .userId(userId)
+                .recordDate(targetDate)
                 .thumbnail(thumbnail != null ? thumbnail : "")
                 .location(command.location())
                 .content(command.content())
@@ -275,7 +295,8 @@ public class RecordService {
         List<GetRecordMusicResponse> recordMusicResponses = recordMusics.stream()
                 .map(GetRecordMusicResponse::from)
                 .toList();
-        return GetRecordDetailResponse.of(savedRecord, recordMusicResponses);
+        LocalDate recordDate = resolveRecordDate(savedRecord);
+        return GetRecordDetailResponse.of(recordDate, savedRecord, recordMusicResponses);
     }
 
     private void updateMusics(Record record, List<CreateRecordMusicCommand> musics) {

--- a/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
+++ b/src/main/java/dalgrock/playlist/service/dto/command/CreateRecordCommand.java
@@ -7,6 +7,9 @@ public record CreateRecordCommand(
         List<String> emotions,
         String content,
         List<String> situations,
-        String location
+        String location,
+        Integer year,
+        Integer month,
+        Integer day
 ) {
 }

--- a/src/main/java/dalgrock/playlist/service/dto/response/GetRecordDetailResponse.java
+++ b/src/main/java/dalgrock/playlist/service/dto/response/GetRecordDetailResponse.java
@@ -1,9 +1,11 @@
 package dalgrock.playlist.service.dto.response;
 
 import dalgrock.playlist.model.Record;
+import java.time.LocalDate;
 import java.util.List;
 
 public record GetRecordDetailResponse(
+        LocalDate recordDate,
         List<GetRecordMusicResponse> music,
         List<String> emotions,
         String content,
@@ -11,8 +13,9 @@ public record GetRecordDetailResponse(
         String location
 ) {
 
-    public static GetRecordDetailResponse of(Record record, List<GetRecordMusicResponse> recordMusics) {
+    public static GetRecordDetailResponse of(LocalDate recordDate, Record record, List<GetRecordMusicResponse> recordMusics) {
         return new GetRecordDetailResponse(
+                recordDate,
                 recordMusics,
                 record.getEmotionsToString(),
                 record.getContent(),

--- a/src/main/resources/db/add-record-date-to-records.sql
+++ b/src/main/resources/db/add-record-date-to-records.sql
@@ -1,0 +1,3 @@
+-- Add record_date column for optional record date (run manually if needed)
+-- When null, record date is derived from created_at.
+ALTER TABLE records ADD COLUMN IF NOT EXISTS record_date DATE;


### PR DESCRIPTION
## Issue Number

closed #55

## As is

- 기록 상세 조회(`GET /v1/records/detail/{recordId}`) 응답에 **기록 날짜**가 없었습니다.
- 기록 추가 시 **날짜를 지정할 수 없어** 항상 "오늘"로만 등록되었습니다.

## To be

- 기록 상세 조회 응답에 **recordDate** 필드를 추가하여 해당 기록의 날짜를 반환합니다.
- 기록 추가 시 **year, month, day**를 옵셔널로 받으며, 셋 다 있으면 해당 날짜로, 하나라도 없으면 **오늘 날짜**로 등록합니다.