### PR TITLE
fix: GET /test/weekly-report 호출 시 항상 새로 분석 생성

### DIFF
--- a/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
+++ b/src/main/java/dalgrock/playlist/service/WeeklyReportGenerationService.java
@@ -109,10 +109,6 @@ public class WeeklyReportGenerationService {
                         .status(ReportStatus.CREATED)
                         .build()));
 
-        if (report.getStatus() == ReportStatus.COMPLETED) {
-            log.info("이미 완료된 리포트입니다. userId={}, weeklyId={}", userId, weekly.getId());
-            return Optional.of(report);
-        }
         if (report.getStatus() == ReportStatus.PROCESSING) {
             log.warn("이미 처리 중인 리포트입니다. userId={}, weeklyId={}", userId, weekly.getId());
             return Optional.empty();


### PR DESCRIPTION
## Summary

- `GET /test/weekly-report` 호출 시 이미 `COMPLETED` 상태의 리포트가 존재해도 LLM을 재호출해 새로운 분석을 생성하도록 수정
- `WeeklyReportGenerationService.generateReport()`에서 COMPLETED 상태 조기 반환 로직 제거

## 변경 내용

**`WeeklyReportGenerationService.java`**

기존에는 동일 userId + weeklyId에 대해 `COMPLETED` 리포트가 있으면 즉시 반환:
```java
if (report.getStatus() == ReportStatus.COMPLETED) {
    log.info("이미 완료된 리포트입니다. userId={}, weeklyId={}", userId, weekly.getId());
    return Optional.of(report);  // LLM 재호출 안 됨
}
```

COMPLETED 조기 반환 블록을 제거 → 매 호출 시 `startProcessing()` → LLM 재호출 → 새 content 저장

`PROCESSING` 체크는 유지 (동시 요청 중복 방지)

## Test plan

- [ ] `GET /test/weekly-report?userId=1&year=2026&month=2&week=4` 최초 호출 → COMPLETED 저장 확인
- [ ] 같은 파라미터로 재호출 → 응답 `content`가 새로 생성된 내용인지 확인
- [ ] 로그에 "이미 완료된 리포트입니다" 메시지 미출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)